### PR TITLE
Adding VC.opendb to ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+#Visual Studio specific files
+*.VC.opendb


### PR DESCRIPTION
This ignores the VC.opendb file that is created in VS2015 Update 1 with C++ projects