### PR TITLE
Add NuGet Packages into AboutForm

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/AboutForm.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/AboutForm.cs
@@ -39,6 +39,10 @@ namespace OpenLiveWriter.PostEditor
 
         // Copyright notices are not to be localized.
         string[] credits = {
+            "DeltaCompressionDotNet (MS-PL) Copyright © Todd Aspeotis 2013 \nhttps://github.com/taspeotis/DeltaCompressionDotNet",
+            "Mono.Cecil (MIT) Copyright © 2008 - 2015 Jb Evain Copyright © 2008 - 2011 Novell, Inc \nhttps://github.com/jbevain/cecil",
+            "Splat (MIT) Copyright © 2013 Paul Betts \nhttps://github.com/paulcbetts/splat/",
+            "Squirrel.Windows (MIT) Copyright © 2012 GitHub, Inc. \n https://github.com/squirrel/squirrel.windows",
             /* XmpMetadata.cs */ "Portions Copyright © 2011 Omar Shahine, licensed under Creative Commons Attribution 3.0 Unported License.",
             /* Brian Lambert */ "Portions Copyright © 2003 Brian Lambert, used with permission of the author under the MIT License.",
         };


### PR DESCRIPTION
We use some awesome bits of open source like Squirrel, Splat, Mono.Cecil & DeltaCompressionDotNet - add links to them in the AboutForm.

I'd like for the AboutForm to be a lot nicer (I think the GitHub Desktop does a really good job with theirs) but this is a quick hack to make sure we at least give them some props and make sure folks can easily see where to get those libraries.(Fixes my borked #43)