### PR TITLE
Adding Nuget config file

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet" value="https://nuget.org/api/v2/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Build would not work out of the box on my machine - possibly because global Nuget config was stored in %userprofile%\appdata\roaming.  Having a project-specific config will fix this issue