### PR TITLE
Beta update fix

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateSettings.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateSettings.cs
@@ -13,10 +13,7 @@ namespace OpenLiveWriter.PostEditor.Updates
     {
         static UpdateSettings()
         {
-            // Force these settings temporarily in case other devs already got defaults set.
-            // AutoUpdate = true;
-            // CheckForBetaUpdates = false;
-            // UpdateDownloadUrl = UPDATEDOWNLOADURL;
+            // Force these settings temporarily in case people already got defaults set.
             BetaUpdateDownloadUrl = BETAUPDATEDOWNLOADURL;
         }
 
@@ -50,7 +47,7 @@ namespace OpenLiveWriter.PostEditor.Updates
         private const string CHECKUPDATESURL = "CheckUpdatesUrl";
         private const string UPDATEDOWNLOADURL = "https://openlivewriter.azureedge.net/stable/Releases"; // Location of signed builds
         private const string CHECKBETAUPDATESURL = "CheckBetaUpdatesUrl";
-        private const string BETAUPDATEDOWNLOADURL = "https://olw.blob.core.windows.net/nightly/Releases/"; // Location of CI builds
+        private const string BETAUPDATEDOWNLOADURL = "https://olw.blob.core.windows.net/nightly/Releases"; // Location of CI builds
 
         private static readonly SettingsPersisterHelper settings = ApplicationEnvironment.UserSettingsRoot.GetSubSettings("Updates");
     }

--- a/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateSettings.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateSettings.cs
@@ -14,9 +14,9 @@ namespace OpenLiveWriter.PostEditor.Updates
         static UpdateSettings()
         {
             // Force these settings temporarily in case other devs already got defaults set.
-            AutoUpdate = true;
-            CheckForBetaUpdates = false;
-            UpdateDownloadUrl = UPDATEDOWNLOADURL;
+            // AutoUpdate = true;
+            // CheckForBetaUpdates = false;
+            // UpdateDownloadUrl = UPDATEDOWNLOADURL;
             BetaUpdateDownloadUrl = BETAUPDATEDOWNLOADURL;
         }
 
@@ -48,9 +48,9 @@ namespace OpenLiveWriter.PostEditor.Updates
         private const string CHECKFORBETAUPDATES = "CheckForBetaUpdates";
 
         private const string CHECKUPDATESURL = "CheckUpdatesUrl";
-        private const string UPDATEDOWNLOADURL = "https://openlivewriter.azureedge.net/stable/Releases";
+        private const string UPDATEDOWNLOADURL = "https://openlivewriter.azureedge.net/stable/Releases"; // Location of signed builds
         private const string CHECKBETAUPDATESURL = "CheckBetaUpdatesUrl";
-        private const string BETAUPDATEDOWNLOADURL = "https://openlivewriter.azureedge.net/nightly/Releases";
+        private const string BETAUPDATEDOWNLOADURL = "https://olw.blob.core.windows.net/nightly/Releases/"; // Location of CI builds
 
         private static readonly SettingsPersisterHelper settings = ApplicationEnvironment.UserSettingsRoot.GetSubSettings("Updates");
     }

--- a/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateSettings.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateSettings.cs
@@ -25,7 +25,7 @@ namespace OpenLiveWriter.PostEditor.Updates
 
         public static bool CheckForBetaUpdates
         {
-            get { return settings.GetBoolean(CHECKFORBETAUPDATES, true); }
+            get { return settings.GetBoolean(CHECKFORBETAUPDATES, false); }
             set { settings.SetBoolean(CHECKFORBETAUPDATES, value); }
         }
 


### PR DESCRIPTION
The UpdateManager was overriding settings stored in the registry therefore we where not possible to switch onto the channel for CI build updates.

Remove logic that overwrites registry settings as it is no longer needed.
Set beta channel to come direct from blob store rather than via CDN.
Set the default value for beta updates when no registry key is present to be false.