### PR TITLE
Removing unused using in codes under BlogRunner.Core project

### DIFF
--- a/src/managed/BlogRunner.Core/BlogUtil.cs
+++ b/src/managed/BlogRunner.Core/BlogUtil.cs
@@ -2,17 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using BlogRunner.Core.Config;
-using OpenLiveWriter.Extensibility.BlogClient;
-using System.Xml;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Net;
-using System.IO;
-using OpenLiveWriter.HtmlParser.Parser;
-using System.Net.Cache;
 
 namespace BlogRunner.Core
 {

--- a/src/managed/BlogRunner.Core/Config/Blog.cs
+++ b/src/managed/BlogRunner.Core/Config/Blog.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace BlogRunner.Core.Config

--- a/src/managed/BlogRunner.Core/Config/Config.cs
+++ b/src/managed/BlogRunner.Core/Config/Config.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 using System.IO;

--- a/src/managed/BlogRunner.Core/Config/CoreCommandLineOptions.cs
+++ b/src/managed/BlogRunner.Core/Config/CoreCommandLineOptions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using OpenLiveWriter.CoreServices;
 
 namespace BlogRunner.Core.Config

--- a/src/managed/BlogRunner.Core/Config/Provider.cs
+++ b/src/managed/BlogRunner.Core/Config/Provider.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml.Serialization;
 using System.Xml;
 

--- a/src/managed/BlogRunner.Core/ITestResult.cs
+++ b/src/managed/BlogRunner.Core/ITestResult.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using BlogRunner.Core.Config;
 using System.IO;
 using System.Globalization;
 

--- a/src/managed/BlogRunner.Core/Log.cs
+++ b/src/managed/BlogRunner.Core/Log.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace BlogRunner.Core
 {

--- a/src/managed/BlogRunner.Core/Test.cs
+++ b/src/managed/BlogRunner.Core/Test.cs
@@ -2,17 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Net.Cache;
 using System.Text;
-using OpenLiveWriter.CoreServices;
 using OpenLiveWriter.Extensibility.BlogClient;
 using BlogRunner.Core.Config;
 using System.Xml;
 using System.Threading;
 using System.Net;
 using System.Text.RegularExpressions;
+using OpenLiveWriter.CoreServices;
 
 namespace BlogRunner.Core
 {

--- a/src/managed/BlogRunner.Core/TestRunner.cs
+++ b/src/managed/BlogRunner.Core/TestRunner.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using BlogRunner.Core.Config;
 using OpenLiveWriter.BlogClient.Clients;
 using OpenLiveWriter.BlogClient;
 using OpenLiveWriter.PostEditor.Configuration;
 using Blog = BlogRunner.Core.Config.Blog;
 using OpenLiveWriter.Extensibility.BlogClient;
-using System.Collections;
-using System.Diagnostics;
 using System.Xml;
 
 namespace BlogRunner.Core

--- a/src/managed/BlogRunner.Core/Tests/CompositePostTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/CompositePostTest.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 using OpenLiveWriter.Extensibility.BlogClient;
 
 namespace BlogRunner.Core.Tests

--- a/src/managed/BlogRunner.Core/Tests/SupportsEmbedsTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/SupportsEmbedsTest.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
 
 namespace BlogRunner.Core.Tests
 {

--- a/src/managed/BlogRunner.Core/Tests/SupportsEmptyTitlesTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/SupportsEmptyTitlesTest.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml;
 using OpenLiveWriter.Extensibility.BlogClient;
 

--- a/src/managed/BlogRunner.Core/Tests/SupportsMultipleCategoriesTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/SupportsMultipleCategoriesTest.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using BlogRunner.Core.Config;
 using OpenLiveWriter.Extensibility.BlogClient;
-using System.Configuration;
 
 namespace BlogRunner.Core.Tests
 {

--- a/src/managed/BlogRunner.Core/Tests/SupportsPostAsDraftTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/SupportsPostAsDraftTest.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using OpenLiveWriter.Extensibility.BlogClient;
 
 namespace BlogRunner.Core.Tests

--- a/src/managed/BlogRunner.Core/Tests/SupportsScriptsTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/SupportsScriptsTest.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Diagnostics;
 
 namespace BlogRunner.Core.Tests

--- a/src/managed/BlogRunner.Core/Tests/TitleEncodingTest.cs
+++ b/src/managed/BlogRunner.Core/Tests/TitleEncodingTest.cs
@@ -2,13 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Xml;
 using OpenLiveWriter.Extensibility.BlogClient;
-using System.Net;
 using System.Text.RegularExpressions;
-using System.Threading;
 using OpenLiveWriter.HtmlParser.Parser;
 
 namespace BlogRunner.Core.Tests


### PR DESCRIPTION
This pull request consists of commits that basically remove unused namespace in `using` declarations in the codes under BlogRunner.Core project. This pull request has no logical/flow changes at all.