### PR TITLE
Add split post capability to GoogleBloggerV3Client

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
@@ -151,6 +151,7 @@ namespace OpenLiveWriter.BlogClient.Clients
             clientOptions.SupportsKeywords = true;
             clientOptions.SupportsGetKeywords = false;
             clientOptions.SupportsPages = true;
+            clientOptions.SupportsExtendedEntries = true;
             _clientOptions = clientOptions;
 
             _nsMgr = new XmlNamespaceManager(new NameTable());


### PR DESCRIPTION
You know when you start on something expecting it to be hard and then it works and you don't quite understand why. This is one of those.

Added the clientOptions.SupportsExtendedEntries attribute to the GoogleBloggerv3Client so that I could then start debugging how to get it working but the code seems to work as is once the capability is set.  Have to confess that this surprised me as I was expecting to have to do more work to get this up and running. New posts work, editing posts works, save local drafts works.

Anyone see anything that I missed?