### PR TITLE
Enable creation of blogger labels

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
@@ -149,7 +149,7 @@ namespace OpenLiveWriter.BlogClient.Clients
             clientOptions.SupportsSlug = false;
             clientOptions.SupportsFileUpload = true;
             clientOptions.SupportsKeywords = true;
-            clientOptions.SupportsGetKeywords = false;
+            clientOptions.SupportsGetKeywords = true;
             clientOptions.SupportsPages = true;
             clientOptions.SupportsExtendedEntries = true;
             _clientOptions = clientOptions;
@@ -301,7 +301,7 @@ namespace OpenLiveWriter.BlogClient.Clients
 
         public BlogPostKeyword[] GetKeywords(string blogId)
         {
-            Trace.Fail("Google Blogger does not support GetKeywords!");
+            // Google Blogger does not support get labels
             return new BlogPostKeyword[] { };
         }
 


### PR DESCRIPTION
Add support for labels in Google Blogger.  I think this fixes #157.  Note that you can set your labels by providing a comma deliminated list but you cannot (yet) get a list of unique labels from the server so pressing the refresh button does nothing.

![image](https://cloud.githubusercontent.com/assets/856858/11875921/f8636eac-a4de-11e5-919e-a4a0a1764d47.png)

