### PR TITLE
Issue #26 - OLW won't open local drafts or published posts, throws an UnauthorizedAccessException

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/BlogPostSupportingFileStorage.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/BlogPostSupportingFileStorage.cs
@@ -141,7 +141,7 @@ namespace OpenLiveWriter.PostEditor
 
         //ToDo: OLW Spell Checker
         // NOTE: hardcode to sentry spelling engine -- need to unroll this if we switch engines
-        private static readonly string CONTEXT_DICTIONARY_FILE = string.Empty; // SentrySpellingChecker.ContextDictionaryFileName ;
+        private static readonly string CONTEXT_DICTIONARY_FILE = "context.tlx";
 
         private DirectoryInfo _storageDirectory;
     }


### PR DESCRIPTION
The root cause here is that we accidentally made a breaking change when we removed the spell checking logic. We changed the CONTEXT_DICTIONARY_FILE constant from "context.tlx" to string.Empty. That means in the WriteSpellingContextDictionary() and ReadSpellingContextDictionary() methods, we were resolving a dictionary path as Path.Combine(SpellingContextDirectory, string.Empty); and then tried to create a FileStream on a directory. The fix here is simple, just change the dictionary filename back to "context.tlx".