### PR TITLE
Preventing making the document 'dirty' during initialization

### DIFF
--- a/src/managed/OpenLiveWriter.Mshtml/MshtmlEditor.cs
+++ b/src/managed/OpenLiveWriter.Mshtml/MshtmlEditor.cs
@@ -190,8 +190,14 @@ namespace OpenLiveWriter.Mshtml
                     // register for dirty range
                     mshtmlControl.MarkupContainer.RegisterForDirtyRange(this, out _changeSinkCookie);
 
-                    // perform document complete actions
-                    OnDocumentComplete();
+                    // During performing the document complete action, *something* is causing a document change log, which causes
+                    // IHtmlChangeSink.Notify to fire, making the document 'dirty' even when nothing was changed.
+                    // Suppressing handling of the 'dirty' notification until after document completion actions.
+                    using (SuspendNotification())
+                    {
+                        // perform document complete actions
+                        OnDocumentComplete();
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
This fixes #65.

Sometime during the completion callback for the document, **something** is mshtml is causing `IHtmlChangeSink.Notify` event to fire, causing setting the document to 'dirty', even if nothing really was changed. This PR fixes the problem by suppressing handling the Notify event during the completion callback. For more information, see the original issue #65.