### PR TITLE
Fix issue with spaces in username

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -28,12 +28,12 @@ IF NOT EXIST %MSBUILD14_TOOLS_PATH% (
 
 IF EXIST %CACHED_NUGET% goto restore
 echo Downloading latest version of NuGet.exe...
-IF NOT EXIST %LocalAppData%\NuGet md %LocalAppData%\NuGet
+IF NOT EXIST "%LocalAppData%\NuGet" md "%LocalAppData%\NuGet"
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile '%CACHED_NUGET%'"
 
 :restore
 IF EXIST "%~dp0src\packages" goto build
-%CACHED_NUGET% restore %SOLUTION_PATH%
+"%CACHED_NUGET%" restore %SOLUTION_PATH%
 
 :build
 

--- a/src/managed/PostBuild.CreateInstaller/createinstaller.cmd
+++ b/src/managed/PostBuild.CreateInstaller/createinstaller.cmd
@@ -22,7 +22,7 @@ ECHO Created Writer NuGet package.
 MOVE .\Releases\Setup.exe .\Releases\OpenLiveWriterSetup.exe
 ECHO Created Open Live Writer setup file.
 
-%LocalAppData%\Nuget\Nuget.exe pack .\OpenLiveWriter.Install.nuspec -version %dottedVersion% -basepath Releases
+"%LocalAppData%\Nuget\Nuget.exe" pack .\OpenLiveWriter.Install.nuspec -version %dottedVersion% -basepath Releases
 ECHO Created Writer Chocolatey Package
 
 :end


### PR DESCRIPTION
For reasons lost in time my username on my laptop has spaces. That means
`%LocalAppData%` will also have spaces. That means calls to exes in
LocalAppData must be quoted. The `build.cmd` batch file will fail without
such quoted exe names. (Ditto `createinstaller.cmd`)