### PR TITLE
Improved categories filter textbox filtering

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/CategoryControl/TreeCategorySelector.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/CategoryControl/TreeCategorySelector.cs
@@ -252,7 +252,7 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing.CategoryControl
             {
                 Predicate<TreeNode> prefixPredicate = delegate (TreeNode node)
                                           {
-                                              return node.Text.ToLower(CultureInfo.CurrentCulture).StartsWith(criteria);
+                                              return node.Text.ToLower(CultureInfo.CurrentCulture).IndexOf(criteria, StringComparison.CurrentCultureIgnoreCase) >= 0;
                                           };
 
                 if (criteria.Length > 0 && criteria.StartsWith(lastQuery))


### PR DESCRIPTION
This PR addresses issue #389 

With this change, users can filter the categories tree view as expected. The category names will be filtered using a case-insensitive version of String.IndexOf, instead of String.StartsWith.