### PR TITLE
Fix for issue #388 to handle Mnemonics correctly.

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/Layout/GdiTextHelper.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/Layout/GdiTextHelper.cs
@@ -81,7 +81,7 @@ namespace OpenLiveWriter.CoreServices.Layout
                                 textMode == GdiTextDrawMode.EndEllipsis ? User32.DT.END_ELLIPSIS
                                 : textMode == GdiTextDrawMode.WordBreak ? User32.DT.WORDBREAK | User32.DT.END_ELLIPSIS
                                 : User32.DT.WORDBREAK;
-                            if (useMnemonics)
+                            if (!useMnemonics)
                                 flags |= User32.DT.NOPREFIX;
 
                             if (0 == User32.DrawTextEx(hdc, sb, sb.Length, ref rect, flags, ref dtparams))


### PR DESCRIPTION
This PR is supposed to fix issue #388 

Implementation details:
In the code, when parameter *UseMnemonics* was set to **true**, the DT_NOPREFIX flag was set, which actually turns mnemonics of.

The fix was to invert the if-condition.

--Neno