### PR TITLE
Fixed #409 by adding a default constructor to CommandBarControl.

### DIFF
--- a/src/managed/OpenLiveWriter.ApplicationFramework/CommandBarControl.cs
+++ b/src/managed/OpenLiveWriter.ApplicationFramework/CommandBarControl.cs
@@ -22,6 +22,11 @@ namespace OpenLiveWriter.ApplicationFramework
 
         protected CommandBarLightweightControl _commandBar;
 
+        public CommandBarControl()
+        {
+            InitializeComponent();
+        }
+
         public CommandBarControl(CommandBarLightweightControl commandBar, CommandBarDefinition commandBarDefinition)
         {
             // It's important that the commandBarDefinition not be set


### PR DESCRIPTION
WinForms requires a few conventions to be met. All such forms/controls should have a default constructor.