### PR TITLE
Blogger dynamic templates : cut to the chase

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Detection/BlogEditingTemplateDetector.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Detection/BlogEditingTemplateDetector.cs
@@ -404,6 +404,12 @@ namespace OpenLiveWriter.BlogClient.Detection
                     // will be notified that they won't be able to edit with style)
                     _exception = e;
                 }
+                catch (BlogClientAbortGettingTemplateException e)
+                {
+                    _exception = e;
+                    //Do not proceed with the other strategies if getting the template was aborted.
+                    break;
+                }
                 catch (WebException e)
                 {
                     _exception = e;
@@ -465,6 +471,11 @@ namespace OpenLiveWriter.BlogClient.Detection
                         string templateFile = DownloadTemplateFiles(editingTemplate, baseUrl, new ProgressTick(parseTick, 4, 5));
                         templateFiles.Add(new BlogEditingTemplateFile(templateTypes[i], templateFile));
 
+                    }
+                    catch(BlogClientAbortGettingTemplateException)
+                    {
+                        Trace.WriteLine(String.Format(CultureInfo.CurrentCulture, "Failed to download template {0}.  Aborting getting further templates", templateTypes[i].ToString()));
+                        throw;
                     }
                     catch (Exception e)
                     {

--- a/src/managed/OpenLiveWriter.BlogClient/Detection/BlogPostRegionLocatorStrategy.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Detection/BlogPostRegionLocatorStrategy.cs
@@ -362,6 +362,10 @@ namespace OpenLiveWriter.BlogClient.Detection
                 Application.DoEvents();
             }
 
+            //The Google/Blogger dynamic templates load the pages dynmaically usig Ajax, so we dont have any template to use.
+            if (IsUsingDynamicTemplate(doc2))
+                throw new BlogClientAbortGettingTemplateException();
+
             IHTMLElement[] titles = FindText(_titleText, doc2.body);
             IHTMLElement[] bodies = FindText(_bodyText, doc2.body);
             if (titles.Length == 0 || bodies.Length == 0)
@@ -404,6 +408,44 @@ namespace OpenLiveWriter.BlogClient.Detection
             }
             // not in smart content
             return false;
+        }
+
+        private static bool IsUsingDynamicTemplate(IHTMLDocument2 doc2)
+        {
+            IHTMLElement head = GetHeadElement(doc2);
+
+            if(head != null)
+            {
+                var template = GetMetaTagContent(head, "blogger-template");
+
+                return template == "dynamic";
+            }
+
+            return false;
+        }
+
+        private static IHTMLElement GetHeadElement(IHTMLDocument2 doc2)
+        {
+            foreach(IHTMLElement element in doc2.all)
+            {
+                if(element.tagName.ToLower() == "head")
+                {
+                    return element;
+                }
+            }
+            return null;
+        }
+
+        private static string GetMetaTagContent(IHTMLElement head, string name)
+        {
+            foreach(IHTMLElement element in (IHTMLElementCollection)head.children)
+            {
+                if(element.tagName.ToLower() == "meta" && (string)element.getAttribute("name") == name)
+                {
+                    return (string)element.getAttribute("content");
+                }
+            }
+            return null;
         }
 
         private IHTMLElement ScrubPostBodyRegionParentElements(IHTMLElement postBodyElement)

--- a/src/managed/OpenLiveWriter.Extensibility/BlogClient/BlogClientException.cs
+++ b/src/managed/OpenLiveWriter.Extensibility/BlogClient/BlogClientException.cs
@@ -195,6 +195,14 @@ namespace OpenLiveWriter.Extensibility.BlogClient
         }
     }
 
+    public class BlogClientAbortGettingTemplateException : BlogClientException
+    {
+        public BlogClientAbortGettingTemplateException()
+            : base(StringId.BCEOperationCancelledTitle, StringId.BCEOperationCancelledMessage)
+        {
+        }
+    }
+
     public class BlogClientMethodUnsupportedException : BlogClientException
     {
         public BlogClientMethodUnsupportedException(string methodName)


### PR DESCRIPTION
Blogs based on Blogger dynamic templates are essentially SPAs (Single Page Web Application) that uses AJAX to load the blog posts. With OLW's current template detection mechanism, the blog template cannot be detected for blogs using dynamic templates as the HTML content downloaded from server does not contain the post header/body. 

Currently when I try to setup a Blogger blog using Dynamic template on Open Live Writer, this is what happens:

1) I am authenticated using Blogger
2) Open Live Writer tries to download the template, fails.
3) OLW asks me if I want to download the template by publishing a temporary posts, I select "Yes"
4) OLW tries to download the template for about 3 minutes and 50 seconds (!) 
5) OLW tells me that "The blog theme couldn't be downloaded."

With this patch, OLW checks if the blog is using dynamic templates after step 2 (above), if it is, it directly tells the user that "The blog theme couldn't be downloaded." without wasting his/her time.
