### PR TITLE
Support atompub service link with relative url

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Detection/BlogServiceDetector.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Detection/BlogServiceDetector.cs
@@ -162,7 +162,7 @@ namespace OpenLiveWriter.BlogClient.Detection
                 _serviceName = atomProvider.Name;
                 _clientType = atomProvider.ClientType;
                 _blogName = string.Empty;
-                _postApiUrl = linkUrl;
+                _postApiUrl = GetAbsoluteUrl(url, linkUrl);
 
                 IBlogClient client = BlogClientManager.CreateClient(atomProvider.ClientType, _postApiUrl, _credentials);
                 client.VerifyCredentials();
@@ -190,6 +190,19 @@ namespace OpenLiveWriter.BlogClient.Detection
                 return true;
             }
             return false;
+        }
+
+        private string GetAbsoluteUrl(string url, string linkUrl)
+        {
+            Uri absoluteUrl;
+            if (Uri.TryCreate(linkUrl, UriKind.Absolute, out absoluteUrl))
+            {
+                return linkUrl;
+            }
+
+            Uri baseUrl = new Uri(url);
+            absoluteUrl = new Uri(baseUrl, linkUrl);
+            return absoluteUrl.AbsoluteUri;
         }
 
         private class BloggerGeneratorCriterion : IElementPredicate


### PR DESCRIPTION
During blog client detection, if the HTML contains a `<link rel='service' type='application/atomsvc+xml'` element, the href will be parsed as an absolute URI, which fails if it's actually a relative URI. This change attempts to resolve the absolute URI from the relative URI, while also supporting the link being an absolute URI.

Unfortunately the URI is tested with an HTTP connection before returning, so I can't write unit tests for this change (without refactoring to make `BlogClientManager` a mockable interface, rather than static).
