### PR TITLE
Add Per-Monitor DPI Support

### DIFF
--- a/src/managed/OpenLiveWriter/OpenLiveWriter.exe.manifest
+++ b/src/managed/OpenLiveWriter/OpenLiveWriter.exe.manifest
@@ -23,7 +23,7 @@
   <asmv3:application>
     <asmv3:windowsSettings
          xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
+      <dpiAware>true/PM</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
   


### PR DESCRIPTION
Fixes issue #585. Tested on Surface Book with 1440p secondary monitor, scaling appeared same on high DPI monitor and much better on lower DPI monitor.