### PR TITLE
Fix crash caused by addition of Tistory support

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/BlogClientManager.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/BlogClientManager.cs
@@ -134,6 +134,7 @@ namespace OpenLiveWriter.BlogClient.Clients
                         AddClientType(typeof(BloggerAtomClient));
                         AddClientType(typeof(SharePointClient));
                         AddClientType(typeof(WordPressClient));
+                        AddClientType(typeof(TistoryBlogClient));
                     }
                     return _clientTypes;
                 }

--- a/src/managed/OpenLiveWriter.BlogClient/OpenLiveWriter.BlogClient.csproj
+++ b/src/managed/OpenLiveWriter.BlogClient/OpenLiveWriter.BlogClient.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Clients\RedirectHelper.cs" />
     <Compile Include="Clients\SharePointClient.cs" />
     <Compile Include="Clients\WordPressClient.cs" />
+	<Compile Include="Clients\TistoryBlogClient.cs" />
     <Compile Include="Clients\XmlRestRequestHelper.cs" />
     <Compile Include="Clients\XmlRpcBlogClient.cs" />
     <Compile Include="Detection\BackgroundColorDetector.cs" />


### PR DESCRIPTION
The commit that added Tistory support didn't add Tistory as a ClientType.  This fixes that oversight.