### PR TITLE
Temporary fix for Picasa web requests

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/BlogClientManager.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/BlogClientManager.cs
@@ -134,6 +134,7 @@ namespace OpenLiveWriter.BlogClient.Clients
                         AddClientType(typeof(BloggerAtomClient));
                         AddClientType(typeof(SharePointClient));
                         AddClientType(typeof(WordPressClient));
+                        AddClientType(typeof(TistoryBlogClient));
                     }
                     return _clientTypes;
                 }

--- a/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerAtomClient.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerAtomClient.cs
@@ -461,7 +461,7 @@ namespace OpenLiveWriter.BlogClient.Clients
 
             //TransientCredentials transientCredentials = Credentials.TransientCredentials as TransientCredentials;
             // TODO: HACK: The deprecation-extension flag keeps the deprecated Picasa API alive.
-            Uri picasaUri = new Uri("http://picasaweb.google.com/data/feed/api/user/default?deprecation-extension=true");
+            Uri picasaUri = new Uri("https://picasaweb.google.com/data/feed/api/user/default?deprecation-extension=true");
 
             try
             {

--- a/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerAtomClient.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerAtomClient.cs
@@ -460,7 +460,8 @@ namespace OpenLiveWriter.BlogClient.Clients
             const string GPHOTO_NS_URI = "http://schemas.google.com/photos/2007";
 
             //TransientCredentials transientCredentials = Credentials.TransientCredentials as TransientCredentials;
-            Uri picasaUri = new Uri("http://picasaweb.google.com/data/feed/api/user/default");
+            // TODO: HACK: The deprecation-extension flag keeps the deprecated Picasa API alive.
+            Uri picasaUri = new Uri("http://picasaweb.google.com/data/feed/api/user/default?deprecation-extension=true");
 
             try
             {

--- a/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
@@ -731,9 +731,9 @@ namespace OpenLiveWriter.BlogClient.Clients
         public string GetBlogImagesAlbum(string albumName, string blogId)
         {
             const string FEED_REL = "http://schemas.google.com/g/2005#feed";
-            
-            Uri picasaUri = new Uri("https://picasaweb.google.com/data/feed/api/user/default");
 
+            // TODO: HACK: The deprecation-extension flag keeps the deprecated Picasa API alive.
+            Uri picasaUri = new Uri("https://picasaweb.google.com/data/feed/api/user/default?deprecation-extension=true");
             var picasaId = string.Empty;
 
             try
@@ -767,7 +767,11 @@ namespace OpenLiveWriter.BlogClient.Clients
                             }
                             string selfHref = AtomEntry.GetLink(entryEl, _nsMgr, FEED_REL, "application/atom+xml", null, reqUri);
                             if (selfHref.Length > 1)
+                            {
+                                // TODO: HACK: This keeps the deprecated Picasa API alive.
+                                selfHref += "&deprecation-extension=true";
                                 return selfHref;
+                            }
                         }
                     }
                 }
@@ -835,7 +839,8 @@ namespace OpenLiveWriter.BlogClient.Clients
                 // for us to use.
                 if (userInfo.BlogUserInfoValue.PhotosAlbumKey != "0")
                 {
-                    var bloggerPicasaUrl = $"https://picasaweb.google.com/data/feed/api/user/{picasaId}/albumid/{userInfo.BlogUserInfoValue.PhotosAlbumKey}";
+                    // TODO: HACK: The deprecation-extension flag keeps the deprecated Picasa API alive.
+                    var bloggerPicasaUrl = $"https://picasaweb.google.com/data/feed/api/user/{picasaId}/albumid/{userInfo.BlogUserInfoValue.PhotosAlbumKey}?deprecation-extension=true";
                     return bloggerPicasaUrl;
                 }
             }

--- a/src/managed/OpenLiveWriter.BlogClient/OpenLiveWriter.BlogClient.csproj
+++ b/src/managed/OpenLiveWriter.BlogClient/OpenLiveWriter.BlogClient.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Clients\RedirectHelper.cs" />
     <Compile Include="Clients\SharePointClient.cs" />
     <Compile Include="Clients\WordPressClient.cs" />
+	<Compile Include="Clients\TistoryBlogClient.cs" />
     <Compile Include="Clients\XmlRestRequestHelper.cs" />
     <Compile Include="Clients\XmlRpcBlogClient.cs" />
     <Compile Include="Detection\BackgroundColorDetector.cs" />

--- a/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
+++ b/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
@@ -15,18 +15,19 @@
     <ProjectGuid>{195A60BF-7A4D-42E6-B5F4-FEBC679E19F0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenLiveWriter.Ribbon</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
+++ b/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{195A60BF-7A4D-42E6-B5F4-FEBC679E19F0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenLiveWriter.Ribbon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Fixes #786 _temporarily_.

This PR provides a temporary fix for [PR #786: Error 400 - The Remote server returned an error 
](https://github.com/OpenLiveWriter/OpenLiveWriter/issues/786), which is caused by Google deprecating the Picasa API for photos.google.com.

Google has provided a [grace period](https://developers.google.com/picasa-web/docs/3.0/deprecation#extension), which extends until 15 March 2019, after which the Picasa API will be turned off for good.

The fix is commented with ``TODO: HACK:`` to emphasize that it won't last. Significant surgery on [GoogleBloggerv3Client.cs](https://github.com/OpenLiveWriter/OpenLiveWriter/blob/master/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs) is necessary to update to the new [Google Photos Library API](https://developers.google.com/picasa-web/docs/3.0/developers_guide_migration).

This PR also carries [PR #721: Fix crash caused by addition of Tistory support](https://github.com/OpenLiveWriter/OpenLiveWriter/pull/721), because it's necessary to keep the app from crashing on startup.


