### PR TITLE
Set MSHTML IE9 Emulation Mode (fixes #829 and others)

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Detection/default.htm
+++ b/src/managed/OpenLiveWriter.BlogClient/Detection/default.htm
@@ -3,7 +3,7 @@
 <HTML>
 <HEAD>
 <META http-equiv="Content-Type" content="text/html; utf-8">
-<META http-equiv="X-UA-Compatible" content="IE=edge" />
+<META http-equiv="X-UA-Compatible" content="IE=EmulateIE9" />
 <LINK href="{0}" type="text/css" rel="stylesheet">
 </HEAD>
 


### PR DESCRIPTION
Set MSHTML into IE9 emulation mode by adjusting X-UA-Compatible in the editing template. IE10 Standards modes and higher no longer support Element Behaviors and HTML components (read more: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/hh801216(v=vs.85)), and as such, table resizing, cell selection, and automatic detection of tables in source, amongst other features, ceased to function.

This PR alters PostHtmlEditingSettings to ensure blog editing templates are placed into EmulateIE9 mode, as well as altering the default template to enable EmulateIE9 mode. This may break in-theme editing of blogs which rely on complex CSS3 styles, however this would be as far as we can get without completely restructuring how editing behaviors attach, or completely replacing MSHTML with another engine.

Related issues: Fixes #829, #715, #667, #626. Possibly fixes #665, more info would be needed.