### PR TITLE
Make Page Parent drop-down fill horizontal space (fixes #828)

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.Designer.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.Designer.cs
@@ -91,27 +91,26 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             this.categoryDropDown.Location = new System.Drawing.Point(8, 10);
             this.categoryDropDown.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.categoryDropDown.Name = "categoryDropDown";
-            this.categoryDropDown.Size = new System.Drawing.Size(162, 21);
+            this.categoryDropDown.Size = new System.Drawing.Size(144, 21);
             this.categoryDropDown.TabIndex = 0;
             // 
             // textTags
             // 
             this.textTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.textTags.DefaultText = null;
-            this.textTags.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.textTags.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.textTags.Location = new System.Drawing.Point(178, 9);
+            this.textTags.Location = new System.Drawing.Point(160, 10);
             this.textTags.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.textTags.Name = "textTags";
             this.textTags.ShowButton = true;
-            this.textTags.Size = new System.Drawing.Size(162, 23);
+            this.textTags.Size = new System.Drawing.Size(198, 20);
             this.textTags.TabIndex = 1;
             // 
             // datePublishDate
             // 
             this.datePublishDate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.datePublishDate.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
-            this.datePublishDate.Location = new System.Drawing.Point(348, 10);
+            this.datePublishDate.Location = new System.Drawing.Point(366, 10);
             this.datePublishDate.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.datePublishDate.Name = "datePublishDate";
             this.datePublishDate.RightToLeftLayout = true;
@@ -123,7 +122,7 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             // 
             this.labelPageParent.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.labelPageParent.AutoSize = true;
-            this.labelPageParent.Location = new System.Drawing.Point(538, 14);
+            this.labelPageParent.Location = new System.Drawing.Point(556, 14);
             this.labelPageParent.Margin = new System.Windows.Forms.Padding(0);
             this.labelPageParent.Name = "labelPageParent";
             this.labelPageParent.Size = new System.Drawing.Size(68, 13);
@@ -136,10 +135,10 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             this.comboPageParent.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.comboPageParent.FormattingEnabled = true;
             this.comboPageParent.IntegralHeight = false;
-            this.comboPageParent.Location = new System.Drawing.Point(606, 10);
+            this.comboPageParent.Location = new System.Drawing.Point(624, 10);
             this.comboPageParent.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.comboPageParent.Name = "comboPageParent";
-            this.comboPageParent.Size = new System.Drawing.Size(121, 21);
+            this.comboPageParent.Size = new System.Drawing.Size(121, 20);
             this.comboPageParent.TabIndex = 4;
             // 
             // labelPageOrder
@@ -156,7 +155,7 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             // textPageOrder
             // 
             this.textPageOrder.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.textPageOrder.Location = new System.Drawing.Point(797, 10);
+            this.textPageOrder.Location = new System.Drawing.Point(815, 10);
             this.textPageOrder.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.textPageOrder.Name = "textPageOrder";
             this.textPageOrder.Size = new System.Drawing.Size(63, 20);

--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.Designer.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.Designer.cs
@@ -145,7 +145,7 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             // 
             this.labelPageOrder.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.labelPageOrder.AutoSize = true;
-            this.labelPageOrder.Location = new System.Drawing.Point(735, 14);
+            this.labelPageOrder.Location = new System.Drawing.Point(753, 14);
             this.labelPageOrder.Margin = new System.Windows.Forms.Padding(0);
             this.labelPageOrder.Name = "labelPageOrder";
             this.labelPageOrder.Size = new System.Drawing.Size(62, 13);

--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.Designer.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.Designer.cs
@@ -34,20 +34,20 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
         private void InitializeComponent()
         {
             this.table = new System.Windows.Forms.TableLayoutPanel();
-            this.labelPageOrder = new System.Windows.Forms.Label();
             this.categoryDropDown = new OpenLiveWriter.PostEditor.PostPropertyEditing.CategoryControl.CategoryDropDownControlM1();
             this.textTags = new OpenLiveWriter.Controls.AutoCompleteTextbox();
             this.datePublishDate = new OpenLiveWriter.PostEditor.PostPropertyEditing.PublishDateTimePicker();
             this.labelPageParent = new System.Windows.Forms.Label();
             this.comboPageParent = new OpenLiveWriter.PostEditor.PostPropertyEditing.PageParentComboBox();
+            this.labelPageOrder = new System.Windows.Forms.Label();
             this.textPageOrder = new OpenLiveWriter.Controls.NumericTextBox();
-            this.panelShadow = new System.Windows.Forms.Panel();
             this.linkViewAll = new System.Windows.Forms.LinkLabel();
+            this.panelShadow = new System.Windows.Forms.Panel();
             this.table.SuspendLayout();
             this.SuspendLayout();
-            //
+            // 
             // table
-            //
+            // 
             this.table.BackColor = System.Drawing.Color.Transparent;
             this.table.ColumnCount = 9;
             this.table.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
@@ -75,20 +75,9 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             this.table.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.table.Size = new System.Drawing.Size(1090, 41);
             this.table.TabIndex = 0;
-            //
-            // labelPageOrder
-            //
-            this.labelPageOrder.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.labelPageOrder.AutoSize = true;
-            this.labelPageOrder.Location = new System.Drawing.Point(753, 14);
-            this.labelPageOrder.Margin = new System.Windows.Forms.Padding(0);
-            this.labelPageOrder.Name = "labelPageOrder";
-            this.labelPageOrder.Size = new System.Drawing.Size(62, 13);
-            this.labelPageOrder.TabIndex = 5;
-            this.labelPageOrder.Text = "Page order:";
-            //
+            // 
             // categoryDropDown
-            //
+            // 
             this.categoryDropDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.categoryDropDown.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.categoryDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -97,85 +86,89 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             this.categoryDropDown.Items.AddRange(new object[] {
             "",
             "",
+            "",
             ""});
             this.categoryDropDown.Location = new System.Drawing.Point(8, 10);
             this.categoryDropDown.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.categoryDropDown.Name = "categoryDropDown";
-            this.categoryDropDown.Size = new System.Drawing.Size(144, 21);
+            this.categoryDropDown.Size = new System.Drawing.Size(162, 21);
             this.categoryDropDown.TabIndex = 0;
-            //
+            // 
             // textTags
-            //
+            // 
             this.textTags.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.textTags.DefaultText = null;
+            this.textTags.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.textTags.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.textTags.Location = new System.Drawing.Point(160, 10);
+            this.textTags.Location = new System.Drawing.Point(178, 9);
             this.textTags.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.textTags.Name = "textTags";
             this.textTags.ShowButton = true;
-            this.textTags.Size = new System.Drawing.Size(198, 20);
+            this.textTags.Size = new System.Drawing.Size(162, 23);
             this.textTags.TabIndex = 1;
-            //
+            // 
             // datePublishDate
-            //
+            // 
             this.datePublishDate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.datePublishDate.Format = DateTimePickerFormat.Custom;
-            this.datePublishDate.Location = new System.Drawing.Point(366, 10);
+            this.datePublishDate.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
+            this.datePublishDate.Location = new System.Drawing.Point(348, 10);
             this.datePublishDate.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.datePublishDate.Name = "datePublishDate";
             this.datePublishDate.RightToLeftLayout = true;
             this.datePublishDate.ShowCheckBox = true;
             this.datePublishDate.Size = new System.Drawing.Size(182, 20);
             this.datePublishDate.TabIndex = 2;
-            //
+            // 
             // labelPageParent
-            //
+            // 
             this.labelPageParent.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.labelPageParent.AutoSize = true;
-            this.labelPageParent.Location = new System.Drawing.Point(556, 14);
+            this.labelPageParent.Location = new System.Drawing.Point(538, 14);
             this.labelPageParent.Margin = new System.Windows.Forms.Padding(0);
             this.labelPageParent.Name = "labelPageParent";
             this.labelPageParent.Size = new System.Drawing.Size(68, 13);
             this.labelPageParent.TabIndex = 3;
             this.labelPageParent.Text = "Page parent:";
-            //
+            // 
             // comboPageParent
-            //
-            this.comboPageParent.Anchor = System.Windows.Forms.AnchorStyles.None;
+            // 
+            this.comboPageParent.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.comboPageParent.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.comboPageParent.FormattingEnabled = true;
             this.comboPageParent.IntegralHeight = false;
-            this.comboPageParent.Location = new System.Drawing.Point(624, 10);
+            this.comboPageParent.Location = new System.Drawing.Point(606, 10);
             this.comboPageParent.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.comboPageParent.Name = "comboPageParent";
-            this.comboPageParent.Size = new System.Drawing.Size(121, 20);
+            this.comboPageParent.Size = new System.Drawing.Size(121, 21);
             this.comboPageParent.TabIndex = 4;
-            //
+            // 
+            // labelPageOrder
+            // 
+            this.labelPageOrder.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.labelPageOrder.AutoSize = true;
+            this.labelPageOrder.Location = new System.Drawing.Point(735, 14);
+            this.labelPageOrder.Margin = new System.Windows.Forms.Padding(0);
+            this.labelPageOrder.Name = "labelPageOrder";
+            this.labelPageOrder.Size = new System.Drawing.Size(62, 13);
+            this.labelPageOrder.TabIndex = 5;
+            this.labelPageOrder.Text = "Page order:";
+            // 
             // textPageOrder
-            //
+            // 
             this.textPageOrder.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.textPageOrder.Location = new System.Drawing.Point(815, 10);
+            this.textPageOrder.Location = new System.Drawing.Point(797, 10);
             this.textPageOrder.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.textPageOrder.Name = "textPageOrder";
             this.textPageOrder.Size = new System.Drawing.Size(63, 20);
             this.textPageOrder.TabIndex = 6;
-            //
-            // panelShadow
-            //
-            this.panelShadow.BackColor = System.Drawing.Color.Transparent;
-            this.panelShadow.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panelShadow.Location = new System.Drawing.Point(0, 41);
-            this.panelShadow.Name = "panelShadow";
-            this.panelShadow.Size = new System.Drawing.Size(1090, 4);
-            this.panelShadow.TabIndex = 1;
-            //
+            // 
             // linkViewAll
-            //
-            this.linkViewAll.ActiveLinkColor = Color.FromArgb(85, 142, 213);
+            // 
+            this.linkViewAll.ActiveLinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(85)))), ((int)(((byte)(142)))), ((int)(((byte)(213)))));
             this.linkViewAll.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.linkViewAll.AutoSize = true;
             this.linkViewAll.LinkBehavior = System.Windows.Forms.LinkBehavior.HoverUnderline;
-            this.linkViewAll.LinkColor = Color.FromArgb(85, 142, 213);
+            this.linkViewAll.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(85)))), ((int)(((byte)(142)))), ((int)(((byte)(213)))));
             this.linkViewAll.Location = new System.Drawing.Point(1038, 14);
             this.linkViewAll.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
             this.linkViewAll.Name = "linkViewAll";
@@ -183,11 +176,20 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             this.linkViewAll.TabIndex = 7;
             this.linkViewAll.TabStop = true;
             this.linkViewAll.Text = "View all";
-            this.linkViewAll.VisitedLinkColor = Color.FromArgb(85, 142, 213);
+            this.linkViewAll.VisitedLinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(85)))), ((int)(((byte)(142)))), ((int)(((byte)(213)))));
             this.linkViewAll.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkViewAll_LinkClicked);
-            //
+            // 
+            // panelShadow
+            // 
+            this.panelShadow.BackColor = System.Drawing.Color.Transparent;
+            this.panelShadow.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panelShadow.Location = new System.Drawing.Point(0, 41);
+            this.panelShadow.Name = "panelShadow";
+            this.panelShadow.Size = new System.Drawing.Size(1090, 4);
+            this.panelShadow.TabIndex = 1;
+            // 
             // PostPropertiesBandControl
-            //
+            // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
             this.BackColor = System.Drawing.SystemColors.Window;
             this.Controls.Add(this.table);

--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.cs
@@ -122,6 +122,17 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             base.OnLoad(args);
 
             FixCategoryDropDown();
+            FixPageParentDropDown();
+        }
+
+        private void FixPageParentDropDown()
+        {
+            // For unknown reasons, the page parent drop down vertically misaligns at runtime
+            // Force it to vertically align with the publish date picker on location change
+            comboPageParent.LocationChanged += delegate
+            {
+                comboPageParent.Top = datePublishDate.Top;
+            };
         }
 
         private void FixCategoryDropDown()

--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.cs
@@ -202,9 +202,34 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
             }
         }
 
+        private bool pageParentVisible = false;
+        private bool PageParentVisible
+        {
+            set
+            {
+                labelPageParent.Visible = comboPageParent.Visible = pageParentVisible = value;
+                if (value) {
+                    // Page Parent selection enabled, set Page Parent combo to fill
+                    table.ColumnStyles[COL_PAGEPARENT].SizeType = SizeType.Percent;
+                    table.ColumnStyles[COL_PAGEPARENT] = new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F);
+                } else
+                {
+                    // Page Parent selection disabled, reset column styles and sizing
+                    table.ColumnStyles[COL_PAGEPARENT].SizeType = SizeType.AutoSize;
+                    table.ColumnStyles[COL_PAGEPARENT] = new System.Windows.Forms.ColumnStyle();
+                }
+                ManageFillerVisibility();
+            }
+        }
+
         private void ManageFillerVisibility()
         {
-            bool shouldShow = !categoryVisible && !tagsVisible;
+            // Only show the filler if:
+            //  - Categories aren't visible
+            //  - Tags aren't visible
+            //  - And editing a Post (not a Page)
+
+            bool shouldShow = !categoryVisible && !tagsVisible && !pageParentVisible;
             table.ColumnStyles[COL_FILLER].SizeType = shouldShow ? SizeType.Percent : SizeType.AutoSize;
         }
 
@@ -257,6 +282,9 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
                 linkViewAll.Visible = showViewAll;
                 CategoryVisible = false;
                 TagsVisible = false;
+
+                PageParentVisible = _clientOptions.SupportsPageParent;
+
                 Visible = showViewAll || _clientOptions.SupportsPageParent || _clientOptions.SupportsPageOrder;
             }
             else
@@ -277,6 +305,8 @@ namespace OpenLiveWriter.PostEditor.PostPropertyEditing
 
                 CategoryVisible = _clientOptions.SupportsCategories;
                 TagsVisible = showTags;
+
+                PageParentVisible = false;
 
                 linkViewAll.Visible = showViewAll;
             }

--- a/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.resx
+++ b/src/managed/OpenLiveWriter.PostEditor/PostPropertyEditing/PostPropertiesBandControl.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
Make the Parent drop-down for Page settings expand to fill all horizontal space, rather than having a static width. This allows page titles longer than the drop-down's previous width to be read. Fixes #828. Screenshot of new drop-down below:

![image](https://user-images.githubusercontent.com/8158648/60392071-8352d700-9b3f-11e9-896f-dd3fb4faa2c1.png)
