### PR TITLE
UpdateManager: don't update if update is older than currently running version (fixes #838)

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateManager.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateManager.cs
@@ -44,7 +44,9 @@ namespace OpenLiveWriter.PostEditor.Updates
                         {
                             var update = await manager.CheckForUpdate();
 
-                            if(update.FutureReleaseEntry.Version < update.CurrentlyInstalledVersion.Version)
+                            if(update != null && 
+                               update.ReleasesToApply.Count > 0 && 
+                               update.FutureReleaseEntry.Version < update.CurrentlyInstalledVersion.Version)
                             {
                                 Trace.WriteLine("Update is older than currently running version, not installing.");
                                 Trace.WriteLine($"Current: {update.CurrentlyInstalledVersion.Version} Update: {update.FutureReleaseEntry.Version}");

--- a/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateManager.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Updates/UpdateManager.cs
@@ -42,6 +42,15 @@ namespace OpenLiveWriter.PostEditor.Updates
                     {
                         using (var manager = new Squirrel.UpdateManager(downloadUrl))
                         {
+                            var update = await manager.CheckForUpdate();
+
+                            if(update.FutureReleaseEntry.Version < update.CurrentlyInstalledVersion.Version)
+                            {
+                                Trace.WriteLine("Update is older than currently running version, not installing.");
+                                Trace.WriteLine($"Current: {update.CurrentlyInstalledVersion.Version} Update: {update.FutureReleaseEntry.Version}");
+                                return;
+                            }
+
                             await manager.UpdateApp();
                         }
                     }


### PR DESCRIPTION
Seems #838 is caused by Squirrel thinking that the current public release is 'newer' than the development release, even though the version number is lower. This change compares the two versions, and will only attempt the Squirrel update if the version number is equal or newer.