### PR TITLE
Insert from web - allowing YouTube URLs

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
@@ -84,7 +84,7 @@
     </editorFormat>
     <embedFormat>
       <![CDATA[
-      <iframe src="http://www.youtube.com/embed/{videoId}&hl=en" width="{width}" height="{height}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <iframe src="http://www.youtube.com/embed/{videoId}" width="{width}" height="{height}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 		]]>
     </embedFormat>
     <embedPatterns>

--- a/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
@@ -77,24 +77,14 @@
   <provider>
     <id>56744E0A-1892-4b56-B7FF-3A2568EE2D27</id>
     <serviceName>YouTube</serviceName>
-    <editorFormat xpp:if="version lt 15.4.3104.0816">
+    <editorFormat>
       <![CDATA[
-		<embed src="http://www.youtube.com/embed/{videoId}" wmode="transparent" width="{width}" height="{height}"></embed>
+		<iframe src="http://www.youtube.com/embed/{videoId}" width="{width}" height="{height}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 		]]>
     </editorFormat>
-    <editorFormat xpp:if="version gte 15.4.3104.0816">
+    <embedFormat>
       <![CDATA[
-		<embed src="http://www.youtube.com/embed/{videoId}?hd=1" wmode="transparent" width="{width}" height="{height}"></embed>
-		]]>
-    </editorFormat>
-    <embedFormat xpp:if="version lt 15.4.3104.0816">
-      <![CDATA[
-      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/embed/{videoId}&hl=en"></param><embed src="http://www.youtube.com/embed/{videoId}&hl=en" width="{width}" height="{height}"></embed></object>
-		]]>
-    </embedFormat>
-    <embedFormat xpp:if="version gte 15.4.3104.0816">
-      <![CDATA[
-      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/embed/{videoId}?hl=en&hd=1"></param><embed src="http://www.youtube.com/embed/{videoId}?hl=en&hd=1" width="{width}" height="{height}"></embed></object>
+      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/embed/{videoId}&hl=en"></param><iframe src="http://www.youtube.com/embed/{videoId}&hl=en" width="{width}" height="{height}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></object>
 		]]>
     </embedFormat>
     <embedPatterns>

--- a/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
@@ -84,7 +84,7 @@
     </editorFormat>
     <embedFormat>
       <![CDATA[
-      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/embed/{videoId}&hl=en"></param><iframe src="http://www.youtube.com/embed/{videoId}&hl=en" width="{width}" height="{height}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></object>
+      <iframe src="http://www.youtube.com/embed/{videoId}&hl=en" width="{width}" height="{height}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 		]]>
     </embedFormat>
     <embedPatterns>

--- a/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
@@ -79,28 +79,28 @@
     <serviceName>YouTube</serviceName>
     <editorFormat xpp:if="version lt 15.4.3104.0816">
       <![CDATA[
-		<embed src="http://www.youtube.com/v/{videoId}" type="application/x-shockwave-flash" wmode="transparent" width="{width}" height="{height}"></embed>
+		<embed src="http://www.youtube.com/embed/{videoId}" wmode="transparent" width="{width}" height="{height}"></embed>
 		]]>
     </editorFormat>
     <editorFormat xpp:if="version gte 15.4.3104.0816">
       <![CDATA[
-		<embed src="http://www.youtube.com/v/{videoId}?hd=1" type="application/x-shockwave-flash" wmode="transparent" width="{width}" height="{height}"></embed>
+		<embed src="http://www.youtube.com/embed/{videoId}?hd=1" wmode="transparent" width="{width}" height="{height}"></embed>
 		]]>
     </editorFormat>
     <embedFormat xpp:if="version lt 15.4.3104.0816">
       <![CDATA[
-      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/v/{videoId}&hl=en"></param><embed src="http://www.youtube.com/v/{videoId}&hl=en" type="application/x-shockwave-flash" width="{width}" height="{height}"></embed></object>
+      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/embed/{videoId}&hl=en"></param><embed src="http://www.youtube.com/embed/{videoId}&hl=en" width="{width}" height="{height}"></embed></object>
 		]]>
     </embedFormat>
     <embedFormat xpp:if="version gte 15.4.3104.0816">
       <![CDATA[
-      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/v/{videoId}?hl=en&hd=1"></param><embed src="http://www.youtube.com/v/{videoId}?hl=en&hd=1" type="application/x-shockwave-flash" width="{width}" height="{height}"></embed></object>
+      <object width="{width}" height="{height}"><param name="movie" value="http://www.youtube.com/embed/{videoId}?hl=en&hd=1"></param><embed src="http://www.youtube.com/embed/{videoId}?hl=en&hd=1" width="{width}" height="{height}"></embed></object>
 		]]>
     </embedFormat>
     <embedPatterns>
       <pattern name="src">
         <![CDATA[
-			http://www.youtube.com/v/(?<id>[^&\?]*)
+			http://www.youtube.com/embed/(?<id>[^&\?]*)
 			]]>
       </pattern>
     </embedPatterns>

--- a/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/VideoProvidersB2.xml
@@ -111,7 +111,7 @@
     </urlFormat>
     <urlPattern>
       <![CDATA[
-      (http://www.youtube.com/user/[^#]*[^\n]*/(?<id>[^&]*)|^http://(.+\.)?youtube.com/watch(\?|\#!)v=(?<id>[^&]*))    
+      ((http|https)://www.youtube.com/user/[^#]*[^\n]*/(?<id>[^&]*)|^(http|https)://(.+\.)?youtube.com/watch(\?|\#!)v=(?<id>[^&]*)|^(http|https)://youtu.be/(?<id>[^&]*))    
 		]]>
     </urlPattern>
     <size xpp:if="version lt 15.4.3104.0816">

--- a/src/managed/OpenLiveWriter.PostEditor/Video/WebVideoSource.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/WebVideoSource.cs
@@ -376,7 +376,7 @@ namespace OpenLiveWriter.PostEditor.Video
 
         private static string CreateHtml(string html, string color)
         {
-            return String.Format(CultureInfo.InvariantCulture, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><head><meta content='IE=Edge' http-equiv='X-UA-Compatible'/></head><body style='margin: 0; padding: 0;background-color: #{1}'>{0}</body></html>", html, color);
+            return String.Format(CultureInfo.InvariantCulture, "<!DOCTYPE html><html><head><meta content='IE=Edge' http-equiv='X-UA-Compatible'/></head><body style='margin: 0; padding: 0;background-color: #{1}'>{0}</body></html>", html, color);
         }
 
         private void lblService_SizeChanged(object sender, EventArgs e)

--- a/src/managed/OpenLiveWriter.PostEditor/Video/WebVideoSource.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Video/WebVideoSource.cs
@@ -376,7 +376,7 @@ namespace OpenLiveWriter.PostEditor.Video
 
         private static string CreateHtml(string html, string color)
         {
-            return String.Format(CultureInfo.InvariantCulture, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><body style='margin: 0; padding: 0;background-color: #{1}'>{0}</body></html>", html, color);
+            return String.Format(CultureInfo.InvariantCulture, "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><head><meta content='IE=Edge' http-equiv='X-UA-Compatible'/></head><body style='margin: 0; padding: 0;background-color: #{1}'>{0}</body></html>", html, color);
         }
 
         private void lblService_SizeChanged(object sender, EventArgs e)


### PR DESCRIPTION
Related to issue #849  

In the 'Insert Video from the web' tab, now we get a preview of the video of youtube URLs containing https and youtu.be and the video can be played too using the HTML5 player in the preview tab. :)
