### PR TITLE
New window is opened when Single window is selected in preferences

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/BlogPostEditingManager.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/BlogPostEditingManager.cs
@@ -716,7 +716,10 @@ namespace OpenLiveWriter.PostEditor
             // as well as the contents of the property tray changing.
             if (currentPostIsEmptyAndUnsaved && isNewPost && !editingContext.BlogPost.IsPage)
             {
-                PostEditorForm.Launch(editingContext);
+                if (PostEditorSettings.PostWindowBehavior == PostWindowBehavior.UseSameWindow)
+                    EditPostWithPostCloseEvent(editingContext);
+                else
+                    PostEditorForm.Launch(editingContext);
                 return;
             }
 


### PR DESCRIPTION
Related to issue #303 

Now, a new window will not open when the posts are empty and the single window is selected in the preferences.