### PR TITLE
Paste fix for non common pictures in clipboard, as mentioned in issue #779 

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/DataObject/DataObjectMeister.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/DataObject/DataObjectMeister.cs
@@ -145,7 +145,7 @@ namespace OpenLiveWriter.CoreServices
             }
         }
         private ImageData m_imageData;
-        private bool haveAttemptedImageCreate = false;
+        public bool haveAttemptedImageCreate = false;
 
         public HTMLMetaData GetMetaDataFromCache(string url)
         {

--- a/src/managed/OpenLiveWriter.CoreServices/DataObject/ImageData.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/DataObject/ImageData.cs
@@ -19,7 +19,9 @@ namespace OpenLiveWriter.CoreServices
         /// <returns>The ImageData, null if no ImageData could be created</returns>
         public static ImageData Create(IDataObject iDataObject)
         {
-            if (!OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.Dib) && !OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.EnhancedMetafile))
+            if (!OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.Dib) 
+                && !OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.Bitmap)
+                && !OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.EnhancedMetafile))
                 return null;
             else
                 return new ImageData(iDataObject);

--- a/src/managed/OpenLiveWriter.HtmlEditor/Marshalling/DataFormatHandlerRegistry.cs
+++ b/src/managed/OpenLiveWriter.HtmlEditor/Marshalling/DataFormatHandlerRegistry.cs
@@ -111,7 +111,11 @@ namespace OpenLiveWriter.HtmlEditor.Marshalling
                 {
                     // create a data format handler and return it
                     DataFormatHandler dataFormatHandler = handlerFactory.CreateFrom(dataMeister, handlerContext);
-                    return dataFormatHandler;
+					// prefer picture data over img url from images copied in webbrowsers
+                    if (dataMeister.haveAttemptedImageCreate)
+                        return dataFormatHandler;
+                    else
+                        dataFormatHandler.Dispose();
                 }
             }
 

--- a/src/managed/OpenLiveWriter.HtmlEditor/Marshalling/DataFormatHandlerRegistry.cs
+++ b/src/managed/OpenLiveWriter.HtmlEditor/Marshalling/DataFormatHandlerRegistry.cs
@@ -112,10 +112,16 @@ namespace OpenLiveWriter.HtmlEditor.Marshalling
                     // create a data format handler and return it
                     DataFormatHandler dataFormatHandler = handlerFactory.CreateFrom(dataMeister, handlerContext);
 					// prefer picture data over img url from images copied in webbrowsers
-                    if (dataMeister.haveAttemptedImageCreate)
-                        return dataFormatHandler;
+                    if (handlerContext == DataFormatHandlerContext.ClipboardPaste)
+                    {
+                        if (dataMeister.haveAttemptedImageCreate)
+                            return dataFormatHandler;
+                        else
+                            dataFormatHandler.Dispose();
+                    }
                     else
-                        dataFormatHandler.Dispose();
+                        return dataFormatHandler;
+
                 }
             }
 


### PR DESCRIPTION
Could you add those modifications suggested in #779 issue? As of now UWP originated clipboard pictures works fine with those modifications, maybe it is different on older versions (Windows 8/8.1), but on Windows 10 seems to work fine with it, specially Windows 10's integrated screen capture (Win+Shift+S), works fine with this change.

Also, pasting images copied from webbrowsers by default **picks the URL src** to embed in an IMG tag **instead of pasting the image data** itself. Most of the times, we need to paste as image instead, e.g. to adjust size and add image effects, which is not possible by pasting the image as IMG tag, so we might need to paste in a thir party image editor just to copy there and paste it again in OLW.

By modifying `DataFormatHandlerRegistry.cs` file seems to do the trick, in `CreateForm` procedure as follows:

```c#
public virtual DataFormatHandler CreateFrom(DataObjectMeister dataMeister, DataFormatHandlerContext handlerContext)
       {
           foreach (IDataFormatHandlerFactory handlerFactory in GetDataFormatHandlers())
           {

               // check if the handler can convert/handle the data
               if (handlerFactory.CanCreateFrom(dataMeister))
               {
                   // create a data format handler and return it
                   DataFormatHandler dataFormatHandler = handlerFactory.CreateFrom(dataMeister, handlerContext);
		    // prefer picture data over img url from images copied in webbrowsers
                    if (handlerContext == DataFormatHandlerContext.ClipboardPaste)
                    {
                        if (dataMeister.haveAttemptedImageCreate)
                            return dataFormatHandler;
                        else
                            dataFormatHandler.Dispose();
                    }
                    else
                        return dataFormatHandler;

               }
           }
           // nobody wanted it!
           return null;
       }    
```

However, it requires to make `DataObjectMeister.cs`'s `haveAttemptedImageCreate` boolean property to public. 

For those still wanting to paste images copied from webbrowsers as IMG tag, **Paste Special** option from **Context Menu** allows to do that with the **Remove Formatting** option. 

Normally Paste Special would show error message for pictures in clipboard **_"Paste special can only be used with HTML and text data. ...."_** but **pictures copied in webbrowsers are different**, since they also **contain text data** for its URL src, alt, etc. which it detects and uses to paste as IMG tag, hence this PR to paste its picture data preferably.
 
Maybe **Paste Special** might also be modified _later_ for pasting images too, specially for picking file format, like JPG/PNG/WEBP, compression level, etc. BTW, I also have a branch at https://github.com/vhanla/OpenLiveWriter/tree/PasteAsJpg based on @ScottIsAFool plugin, to paste JPG instead of PNG integrated and configurable in Options -> Editing which I already mentioned in #138.