### PR TITLE
chore: Update build scripts and C++ project for VS2019/VS2022/2026 compatibility

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,9 @@
 # Cause powershell to fail on errors rather than keep going
 $ErrorActionPreference = "Stop";
 
+# Supported Visual Studio versions: VS2017, VS2019, VS2022, VS2026
+# To override the C++ platform toolset, pass: /p:PlatformToolset=v142 (or v141, v143, v144)
+
 @"
 
 =======================================================
@@ -33,7 +36,7 @@ if (Test-Path $vswherePath) {
     $visualStudioLocation = (Get-VSSetupInstance | Select-VSSetupInstance -Latest).InstallationPath
 }
 
-# Try "Current" path first (VS2019+), then fall back to versioned paths
+# Try "Current" path first (VS2019/VS2022/VS2026+), then fall back to versioned paths
 $msBuildExe = $visualStudioLocation + "\MSBuild\Current\Bin\msbuild.exe"
 IF (-Not (Test-Path -LiteralPath "$msBuildExe" -PathType Leaf))
 {
@@ -44,6 +47,7 @@ IF (-Not (Test-Path -LiteralPath "$msBuildExe" -PathType Leaf))
 {
 	"MSBuild not found at '$msBuildExe'"
 	"In order to build OpenLiveWriter, Visual Studio 2017 or later must be installed."
+	"Supported versions: VS2017, VS2019, VS2022, VS2026"
 	"These can be downloaded from https://visualstudio.microsoft.com/downloads/"
 	exit 101
 }

--- a/build.ps1
+++ b/build.ps1
@@ -23,20 +23,28 @@ if (-Not (Test-Path "$solutionFile" -PathType Leaf))
 =======================================================
 "@
 
-# Install module to allow us to find MSBuild
-# See https://github.com/Microsoft/vssetup.powershell
-Install-Module VSSetup -Scope CurrentUser
+# Use vswhere to find the latest Visual Studio installation
+$vswherePath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (Test-Path $vswherePath) {
+    $visualStudioLocation = & $vswherePath -latest -property installationPath
+} else {
+    # Fallback: try VSSetup module
+    Install-Module VSSetup -Scope CurrentUser -Force
+    $visualStudioLocation = (Get-VSSetupInstance | Select-VSSetupInstance -Latest).InstallationPath
+}
 
-$visualStudioLocation = (Get-VSSetupInstance `
-  | Select-VSSetupInstance -Version '[15.0,16.0)' -Latest).InstallationPath
-
-$msBuildExe = $visualStudioLocation + "\MSBuild\15.0\Bin\msbuild.exe"
+# Try "Current" path first (VS2019+), then fall back to versioned paths
+$msBuildExe = $visualStudioLocation + "\MSBuild\Current\Bin\msbuild.exe"
+IF (-Not (Test-Path -LiteralPath "$msBuildExe" -PathType Leaf))
+{
+    # Try VS2017 path
+    $msBuildExe = $visualStudioLocation + "\MSBuild\15.0\Bin\msbuild.exe"
+}
 IF (-Not (Test-Path -LiteralPath "$msBuildExe" -PathType Leaf))
 {
 	"MSBuild not found at '$msBuildExe'"
-	"In order to build OpenLiveWriter either Visual Studio 2017 (any edition) or Build "
-	"Tools for Visual Studio 2017 must be installed."
-	"These can be downloadd from https://visualstudio.microsoft.com/downloads/"
+	"In order to build OpenLiveWriter, Visual Studio 2017 or later must be installed."
+	"These can be downloaded from https://visualstudio.microsoft.com/downloads/"
 	exit 101
 }
 

--- a/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
+++ b/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
@@ -18,16 +18,18 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- PlatformToolset: Use v143 (VS2022) as default, with fallback support for other versions -->
+  <!-- VS2019=v142, VS2022=v143, VS2026=v144. Override via command line: /p:PlatformToolset=v142 -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
+++ b/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
@@ -15,19 +15,19 @@
     <ProjectGuid>{195A60BF-7A4D-42E6-B5F4-FEBC679E19F0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenLiveWriter.Ribbon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Update build scripts and C++ project configuration to support Visual Studio 2017 through VS2026, making the toolset selection flexible and future-proof.

## Changes

- Update `build.ps1` to use `vswhere.exe` to find the latest Visual Studio installation
- Change MSBuild path lookup to use the `Current` folder (VS2019+) with fallback to versioned paths
- Update `OpenLiveWriter.Ribbon.vcxproj` PlatformToolset to v143 (VS2022) as default
- Make PlatformToolset conditionally overridable via `/p:PlatformToolset=vXXX` command line parameter
- Change `WindowsTargetPlatformVersion` to `10.0` to use the latest installed SDK
- Document supported VS versions (VS2017, VS2019, VS2022, VS2026) and toolset mappings (v141-v144)

## Related Issues

Fixes build failures when only VS2019, VS2022, or VS2026 is installed.

## Testing

- Successfully built the solution with Visual Studio 2022 Professional
- Successfully built the solution with Visual Studio 2019 Professional (using `/p:PlatformToolset=v142`)
- Verified the application launches and runs correctly after build

## Checklist

- [x] I have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/OpenLiveWriter/OpenLiveWriter)
- [x] I have tested my changes locally
- [x] My changes do not introduce new warnings or errors
- [x] I have updated documentation if needed

## Additional Notes

**Toolset version reference:**
| Visual Studio | PlatformToolset |
|---------------|-----------------|
| VS2017        | v141            |
| VS2019        | v142            |
| VS2022        | v143            |
| VS2026        | v144            |

To build with a specific toolset, use: `msbuild /p:PlatformToolset=v142`