### PR TITLE
feat: Add GitHub actions installer generation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,17 @@ jobs:
           Move-Item -Path Releases/Setup.exe -Destination Releases/OpenLiveWriterSetup.exe -Force
 
       - name: Sign installer
-        if: ${{ github.event_name != 'pull_request' && secrets.SIGN_CLIENT_SECRET != '' }}
+        if: github.event_name != 'pull_request'
         env:
           SIGN_CLIENT_SECRET: ${{ secrets.SIGN_CLIENT_SECRET }}
           SIGN_CLIENT_USER: ${{ secrets.SIGN_CLIENT_USER }}
         run: |
+          # Check if signing credentials are available
+          if ([string]::IsNullOrEmpty($env:SIGN_CLIENT_SECRET)) {
+            Write-Host "Signing credentials not available, skipping signing"
+            exit 0
+          }
+          
           # Install SignClient
           dotnet tool install --global SignClient
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Setup NuGet
         uses: nuget/setup-nuget@v2
 
+      - name: Setup .NET SDK (for SignClient)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Restore NuGet packages
         run: nuget restore ${{ env.SOLUTION_PATH }}
 
@@ -45,11 +50,87 @@ jobs:
             /p:Configuration=${{ env.OLW_CONFIG }} `
             /p:PlatformToolset=v143
 
+      - name: Get version
+        id: version
+        shell: cmd
+        run: |
+          set /P VERSION=<version.txt
+          echo VERSION=%VERSION%>> %GITHUB_OUTPUT%
+
+      - name: Create NuGet package for Squirrel
+        run: |
+          nuget pack OpenLiveWriter.nuspec `
+            -Version ${{ steps.version.outputs.VERSION }} `
+            -BasePath src/managed/bin/${{ env.OLW_CONFIG }}/i386/Writer
+
+      - name: Create installer with Squirrel
+        run: |
+          # Sync releases (creates Releases folder if needed)
+          & src/managed/packages/squirrel.windows.1.4.4/tools/SyncReleases.exe `
+            -url=https://olw.blob.core.windows.net/stable/Releases/ `
+            -r=Releases
+          
+          # Create installer using Squirrel
+          & src/managed/packages/squirrel.windows.1.4.4/tools/Squirrel.exe `
+            -i src/managed/OpenLiveWriter.PostEditor/Images/Writer.ico `
+            --no-msi `
+            --releasify OpenLiveWriter.${{ steps.version.outputs.VERSION }}.nupkg
+          
+          # Rename Setup.exe to OpenLiveWriterSetup.exe
+          Move-Item -Path Releases/Setup.exe -Destination Releases/OpenLiveWriterSetup.exe -Force
+
+      - name: Sign installer
+        if: ${{ github.event_name != 'pull_request' && secrets.SIGN_CLIENT_SECRET != '' }}
+        env:
+          SIGN_CLIENT_SECRET: ${{ secrets.SIGN_CLIENT_SECRET }}
+          SIGN_CLIENT_USER: ${{ secrets.SIGN_CLIENT_USER }}
+        run: |
+          # Install SignClient
+          dotnet tool install --global SignClient
+          
+          # Sign the installer
+          $releases = Get-ChildItem -Path Releases -Filter *.exe | Select-Object -ExpandProperty FullName
+          foreach ($release in $releases) {
+            Write-Host "Signing $release"
+            SignClient sign `
+              -c SignClient/appsettings.json `
+              -i $release `
+              -r $env:SIGN_CLIENT_USER `
+              -s $env:SIGN_CLIENT_SECRET `
+              -n "Open Live Writer" `
+              -d "Open Live Writer" `
+              -u "http://openlivewriter.com"
+          }
+
+      - name: Create Chocolatey package
+        run: |
+          nuget pack OpenLiveWriter.Install.nuspec `
+            -Version ${{ steps.version.outputs.VERSION }} `
+            -BasePath Releases `
+            -NoPackageAnalysis
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenLiveWriter-Installer-${{ github.run_number }}
+          path: |
+            Releases/OpenLiveWriterSetup.exe
+            Releases/RELEASES
+            Releases/*.nupkg
+          if-no-files-found: warn
+
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
           name: OpenLiveWriter-Binaries-${{ github.run_number }}
           path: src/managed/bin/${{ env.OLW_CONFIG }}/i386/Writer/
+          if-no-files-found: warn
+
+      - name: Upload Chocolatey package
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenLiveWriter-Chocolatey-${{ github.run_number }}
+          path: OpenLiveWriter.Install.*.nupkg
           if-no-files-found: warn
 
   build-debug:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,8 @@ jobs:
           SIGN_CLIENT_USER: ${{ secrets.SIGN_CLIENT_USER }}
         run: |
           # Check if signing credentials are available
-          if ([string]::IsNullOrEmpty($env:SIGN_CLIENT_SECRET)) {
-            Write-Host "Signing credentials not available, skipping signing"
+          if ([string]::IsNullOrEmpty($env:SIGN_CLIENT_SECRET) -or [string]::IsNullOrEmpty($env:SIGN_CLIENT_USER)) {
+            Write-Host "Signing credentials not available (SIGN_CLIENT_USER or SIGN_CLIENT_SECRET missing), skipping signing"
             exit 0
           }
           
@@ -140,7 +140,7 @@ jobs:
               -s $env:SIGN_CLIENT_SECRET `
               -n "Open Live Writer" `
               -d "Open Live Writer" `
-              -u "http://openlivewriter.com"
+              -u "https://openlivewriter.com"
           }
 
       - name: Create Chocolatey package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI Build
+
+on:
+  push:
+    branches:
+      - master
+      - develop/**
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  SOLUTION_PATH: src/managed/writer.sln
+  OLW_CONFIG: Release
+
+jobs:
+  build:
+    name: Build Open Live Writer
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
+
+      - name: Restore NuGet packages
+        run: nuget restore ${{ env.SOLUTION_PATH }}
+
+      - name: Build solution
+        run: |
+          msbuild ${{ env.SOLUTION_PATH }} `
+            /nologo `
+            /maxcpucount `
+            /verbosity:minimal `
+            /p:Configuration=${{ env.OLW_CONFIG }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenLiveWriter-${{ github.run_number }}
+          path: releases/*
+          if-no-files-found: warn
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenLiveWriter-Binaries-${{ github.run_number }}
+          path: src/managed/bin/${{ env.OLW_CONFIG }}/i386/Writer/
+          if-no-files-found: warn
+
+  build-debug:
+    name: Build Debug Configuration
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
+
+      - name: Restore NuGet packages
+        run: nuget restore ${{ env.SOLUTION_PATH }}
+
+      - name: Build solution (Debug)
+        run: |
+          msbuild ${{ env.SOLUTION_PATH }} `
+            /nologo `
+            /maxcpucount `
+            /verbosity:minimal `
+            /p:Configuration=Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup .NET Framework 4.6.1 Developer Pack
+        run: |
+          choco install netfx-4.6.1-devpack -y --no-progress
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
@@ -38,7 +42,8 @@ jobs:
             /nologo `
             /maxcpucount `
             /verbosity:minimal `
-            /p:Configuration=${{ env.OLW_CONFIG }}
+            /p:Configuration=${{ env.OLW_CONFIG }} `
+            /p:PlatformToolset=v143
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -62,6 +67,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup .NET Framework 4.6.1 Developer Pack
+        run: |
+          choco install netfx-4.6.1-devpack -y --no-progress
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
@@ -77,4 +86,5 @@ jobs:
             /nologo `
             /maxcpucount `
             /verbosity:minimal `
-            /p:Configuration=Debug
+            /p:Configuration=Debug `
+            /p:PlatformToolset=v143

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,6 @@ jobs:
             /p:Configuration=${{ env.OLW_CONFIG }} `
             /p:PlatformToolset=v143
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: OpenLiveWriter-${{ github.run_number }}
-          path: releases/*
-          if-no-files-found: warn
-
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,19 +52,46 @@ jobs:
 
       - name: Get version
         id: version
-        shell: cmd
+        shell: pwsh
         run: |
-          set /P VERSION=<version.txt
-          echo VERSION=%VERSION%>> %GITHUB_OUTPUT%
+          $version = Get-Content version.txt -Raw
+          $version = $version.Trim()
+          Write-Host "Raw version: $version"
+          
+          # NuGet normalizes versions by removing trailing .0
+          # e.g., 0.6.3.0 becomes 0.6.3
+          $parts = $version.Split('.')
+          if ($parts.Count -eq 4 -and $parts[3] -eq '0') {
+            $nugetVersion = "$($parts[0]).$($parts[1]).$($parts[2])"
+          } else {
+            $nugetVersion = $version
+          }
+          Write-Host "NuGet version: $nugetVersion"
+          
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          echo "NUGET_VERSION=$nugetVersion" >> $env:GITHUB_OUTPUT
 
       - name: Create NuGet package for Squirrel
         run: |
           nuget pack OpenLiveWriter.nuspec `
-            -Version ${{ steps.version.outputs.VERSION }} `
+            -Version ${{ steps.version.outputs.NUGET_VERSION }} `
             -BasePath src/managed/bin/${{ env.OLW_CONFIG }}/i386/Writer
+          
+          # List created package
+          Get-ChildItem -Filter "OpenLiveWriter.*.nupkg" | ForEach-Object { Write-Host "Created: $($_.Name)" }
 
       - name: Create installer with Squirrel
         run: |
+          $nupkgFile = "OpenLiveWriter.${{ steps.version.outputs.NUGET_VERSION }}.nupkg"
+          Write-Host "Using package: $nupkgFile"
+          
+          # Verify package exists
+          if (-not (Test-Path $nupkgFile)) {
+            Write-Error "Package not found: $nupkgFile"
+            Get-ChildItem -Filter "*.nupkg"
+            exit 1
+          }
+          
           # Sync releases (creates Releases folder if needed)
           & src/managed/packages/squirrel.windows.1.4.4/tools/SyncReleases.exe `
             -url=https://olw.blob.core.windows.net/stable/Releases/ `
@@ -74,10 +101,18 @@ jobs:
           & src/managed/packages/squirrel.windows.1.4.4/tools/Squirrel.exe `
             -i src/managed/OpenLiveWriter.PostEditor/Images/Writer.ico `
             --no-msi `
-            --releasify OpenLiveWriter.${{ steps.version.outputs.VERSION }}.nupkg
+            --releasify $nupkgFile
+          
+          # Verify Setup.exe was created
+          if (-not (Test-Path "Releases/Setup.exe")) {
+            Write-Error "Setup.exe was not created"
+            Get-ChildItem -Path Releases -ErrorAction SilentlyContinue
+            exit 1
+          }
           
           # Rename Setup.exe to OpenLiveWriterSetup.exe
           Move-Item -Path Releases/Setup.exe -Destination Releases/OpenLiveWriterSetup.exe -Force
+          Write-Host "Installer created: Releases/OpenLiveWriterSetup.exe"
 
       - name: Sign installer
         if: github.event_name != 'pull_request'
@@ -111,7 +146,7 @@ jobs:
       - name: Create Chocolatey package
         run: |
           nuget pack OpenLiveWriter.Install.nuspec `
-            -Version ${{ steps.version.outputs.VERSION }} `
+            -Version ${{ steps.version.outputs.NUGET_VERSION }} `
             -BasePath Releases `
             -NoPackageAnalysis
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,32 +84,59 @@ jobs:
         run: |
           $nupkgFile = "OpenLiveWriter.${{ steps.version.outputs.NUGET_VERSION }}.nupkg"
           Write-Host "Using package: $nupkgFile"
-          
+
           # Verify package exists
           if (-not (Test-Path $nupkgFile)) {
             Write-Error "Package not found: $nupkgFile"
             Get-ChildItem -Filter "*.nupkg"
             exit 1
           }
-          
+
           # Sync releases (creates Releases folder if needed)
           & src/managed/packages/squirrel.windows.1.4.4/tools/SyncReleases.exe `
             -url=https://olw.blob.core.windows.net/stable/Releases/ `
             -r=Releases
-          
+
           # Create installer using Squirrel
-          & src/managed/packages/squirrel.windows.1.4.4/tools/Squirrel.exe `
-            -i src/managed/OpenLiveWriter.PostEditor/Images/Writer.ico `
-            --no-msi `
-            --releasify $nupkgFile
-          
+          # Squirrel.exe spawns Update.exe as a detached child process and exits
+          # immediately. Use Start-Process -Wait to wait for Squirrel.exe itself,
+          # then wait for any lingering Update.exe processes to finish.
+          $squirrelExe = "src/managed/packages/squirrel.windows.1.4.4/tools/Squirrel.exe"
+          $squirrelArgs = @(
+            "-i", "src/managed/OpenLiveWriter.PostEditor/Images/Writer.ico",
+            "--no-msi",
+            "--releasify", $nupkgFile,
+            "--releaseDir", "Releases"
+          )
+          Write-Host "Running: $squirrelExe $($squirrelArgs -join ' ')"
+          $proc = Start-Process -FilePath $squirrelExe -ArgumentList $squirrelArgs `
+            -NoNewWindow -PassThru
+          $proc.WaitForExit()
+          Write-Host "Squirrel.exe exited with code $($proc.ExitCode)"
+
+          # Squirrel 1.4.4 delegates work to Update.exe which may still be running
+          $timeout = 300  # 5 minute timeout
+          $elapsed = 0
+          while ($elapsed -lt $timeout) {
+            $updateProcs = Get-Process -Name "Update" -ErrorAction SilentlyContinue
+            if (-not $updateProcs) { break }
+            Write-Host "Waiting for Update.exe to finish... ($elapsed seconds elapsed)"
+            Start-Sleep -Seconds 5
+            $elapsed += 5
+          }
+
+          # List Releases directory contents for debugging
+          Write-Host "Releases directory contents:"
+          Get-ChildItem -Path Releases -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Host "  $($_.Name) ($($_.Length) bytes)"
+          }
+
           # Verify Setup.exe was created
           if (-not (Test-Path "Releases/Setup.exe")) {
-            Write-Error "Setup.exe was not created"
-            Get-ChildItem -Path Releases -ErrorAction SilentlyContinue
+            Write-Error "Setup.exe was not created by Squirrel"
             exit 1
           }
-          
+
           # Rename Setup.exe to OpenLiveWriterSetup.exe
           Move-Item -Path Releases/Setup.exe -Destination Releases/OpenLiveWriterSetup.exe -Force
           Write-Host "Installer created: Releases/OpenLiveWriterSetup.exe"

--- a/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
+++ b/src/unmanaged/OpenLiveWriter.Ribbon/OpenLiveWriter.Ribbon.vcxproj
@@ -15,19 +15,21 @@
     <ProjectGuid>{195A60BF-7A4D-42E6-B5F4-FEBC679E19F0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>OpenLiveWriter.Ribbon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <!-- PlatformToolset: Use v143 (VS2022) as default, with fallback support for other versions -->
+  <!-- VS2019=v142, VS2022=v143, VS2026=v144. Override via command line: /p:PlatformToolset=v142 -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolset)'==''">v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Extends the GitHub Actions CI workflow to create a full installer package using Squirrel and adds code signing support via the .NET Foundation's SignClient service.

## Changes

- Added step to create NuGet package for Squirrel from compiled binaries
- Added version normalization to handle NuGet's trailing `.0` removal (e.g., `0.6.3.0` → `0.6.3`)
- Added Squirrel installer creation using existing `squirrel.windows.1.4.4` tools
- Added code signing with SignClient (conditional - only runs when secrets are available)
- Added Chocolatey package creation
- Separated artifact uploads: installer, binaries, and Chocolatey packages
- Added verification steps and debugging output for troubleshooting

## Testing

- Workflow syntax validated
- Installer creation mirrors existing `createinstaller.cmd` process
- Code signing is conditional and will skip gracefully if secrets are not configured
- Pull requests will not attempt signing (security best practice)

## Checklist

- [x] I have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/OpenLiveWriter/OpenLiveWriter)
- [x] I have tested my changes on GitHub, as much as I can without the secrets.
- [ ] My changes do not introduce new warnings or errors
- [x] I have updated documentation if needed

## Required GitHub Secrets Setup

To enable code signing, repository administrators must configure the following secrets in **Settings → Secrets and variables → Actions → Repository secrets**:

| Secret Name | Description | Source |
|-------------|-------------|--------|
| `SIGN_CLIENT_USER` | .NET Foundation SignClient username/email | Contact .NET Foundation |
| `SIGN_CLIENT_SECRET` | .NET Foundation SignClient secret/password | Contact .NET Foundation |

### How to Add Secrets

1. Go to **Repository Settings** → **Secrets and variables** → **Actions**
2. Click **New repository secret**
3. Add each secret with the exact name shown above
4. The values should match the credentials used in the existing AppVeyor configuration

### SignClient Configuration

The signing uses the .NET Foundation's code signing service configured in `SignClient/appsettings.json`:
- **Service URL**: `https://codesign.dotnetfoundation.org/`
- **Tenant**: .NET Foundation Azure AD

### Notes on Signing

- **Pull requests**: Signing is skipped entirely (secrets not exposed to PRs)
- **Push events without secrets**: Signing step runs but exits gracefully with a message
- **Push events with secrets**: Full signing is performed on the installer

## Artifacts Produced

| Artifact | Contents |
|----------|----------|
| `OpenLiveWriter-Installer-{run}` | `OpenLiveWriterSetup.exe`, `RELEASES` file, Squirrel nupkg files |
| `OpenLiveWriter-Binaries-{run}` | Compiled application binaries |
| `OpenLiveWriter-Chocolatey-{run}` | Chocolatey package for distribution |

## Migration from AppVeyor

The existing AppVeyor secrets can be migrated to GitHub Actions:

| AppVeyor Variable | GitHub Secret |
|-------------------|---------------|
| `SignClientUser` (secure) | `SIGN_CLIENT_USER` |
| `SignClientSecret` (secure) | `SIGN_CLIENT_SECRET` |

Note: The Blogger API credentials (`OlwBloggerClientId`, `OlwBloggerClientSecret`) are handled at build time via MSBuild targets and don't require GitHub secrets for CI builds.