### PR TITLE
enable SupportsGetKeywords for WordPress

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/WordPressClient.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/WordPressClient.cs
@@ -46,6 +46,7 @@ namespace OpenLiveWriter.BlogClient.Clients
 
             // add support for wp-api features
             clientOptions.SupportsKeywords = true;
+            clientOptions.SupportsGetKeywords = true;
             clientOptions.SupportsPages = true;
             clientOptions.SupportsPageParent = true;
             clientOptions.SupportsPageOrder = true;


### PR DESCRIPTION
## Description

Enable `SupportsGetKeywords` for WordPress.

Allow OLW to fetch tags.

## Changes

add `clientOptions.SupportsGetKeywords = true;` in `WordPressClient`.

## Related Issues

<!-- Link any related issues this PR addresses. Use "Fixes #123" or "Closes #123" to auto-close issues when merged. -->

## Testing

I had test with my Wordpress.com instance

## Checklist

- [x] I have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/OpenLiveWriter/OpenLiveWriter)
- [x] I have tested my changes locally
- [x] My changes do not introduce new warnings or errors
- [ ] I have updated documentation if needed

## Additional Notes

<!-- Any additional information, screenshots, or context that reviewers should know about. -->

