### PR TITLE
Fix user-agent string triggering anti-bot warnings

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Providers/BlogProviders.xml
+++ b/src/managed/OpenLiveWriter.BlogClient/Providers/BlogProviders.xml
@@ -35,7 +35,7 @@
 		<clientType>MovableType</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<username>.wordpress.com/xmlrpc.php
+		https://<username>.wordpress.com/xmlrpc.php
 		]]>
 		</postApiUrl>						
 		<homepageUrlPattern>\.wordpress\.com</homepageUrlPattern>
@@ -58,7 +58,7 @@
 		<clientType>MovableType</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://www.typepad.com/t/api
+		https://www.typepad.com/t/api
 		]]>
 		</postApiUrl>				
 		<homepageUrlPattern>\.typepad\.com</homepageUrlPattern>
@@ -79,7 +79,7 @@
 	    <clientType>Blogger2</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://api.blogger.com/api
+		https://api.blogger.com/api
 		]]>
 		</postApiUrl>
 		<homepageUrlPattern>\.blogspot\.com</homepageUrlPattern>
@@ -102,7 +102,7 @@
 		<clientType>LiveJournal</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://www.livejournal.com/interface/blogger
+		https://www.livejournal.com/interface/blogger
 		]]>
 		</postApiUrl>
 		<homepageUrlPattern>\.livejournal\.com</homepageUrlPattern>
@@ -118,7 +118,7 @@
 		<clientType>MovableType</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<hostname>/<mt_path>/mt-xmlrpc.cgi
+		https://<hostname>/<mt_path>/mt-xmlrpc.cgi
 		]]>
 		</postApiUrl>
 		<rsdEngineNamePattern>Movable Type</rsdEngineNamePattern>
@@ -133,7 +133,7 @@
 		<clientType>MovableType</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<hostname>/<wp_path>/xmlrpc.php
+		https://<hostname>/<wp_path>/xmlrpc.php
 		]]>
 		</postApiUrl>
 		<postDateFormat>yyyyMMdd'T'HH':'mm':'ss</postDateFormat>
@@ -162,7 +162,7 @@
 		<clientType>Metaweblog</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<hostname>/blogs/metablog.ashx
+		https://<hostname>/blogs/metablog.ashx
 		]]>
 		</postApiUrl>
 		<useLocalTime>Yes</useLocalTime>
@@ -178,7 +178,7 @@
 		<clientType>Metaweblog</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<hostname>/blog/blogger.aspx
+		https://<hostname>/blog/blogger.aspx
 		]]>
 		</postApiUrl>			
 		<reportingKey>zi</reportingKey>		
@@ -191,7 +191,7 @@
 		<clientType>Metaweblog</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<hostname>/<mw-script>
+		https://<hostname>/<mw-script>
 		]]>
 		</postApiUrl>			
 		<postDateFormat>yyyyMMdd'T'HH':'mm':'ss</postDateFormat>
@@ -204,7 +204,7 @@
 		<clientType>MovableType</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://<hostname>/<mt-script>
+		https://<hostname>/<mt-script>
 		]]>
 		</postApiUrl>					
 		<reportingKey>zm</reportingKey>				
@@ -217,7 +217,7 @@
 		<clientType>Metaweblog</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://blogs.msdn.com/metablog.ashx
+		https://blogs.msdn.com/metablog.ashx
 		]]>
 		</postApiUrl>
 		<homepageUrlPattern>blogs\.msdn\.com</homepageUrlPattern>
@@ -235,7 +235,7 @@
 		<clientType>Metaweblog</clientType>
 		<postApiUrl>
 		<![CDATA[
-		http://blogs.technet.com/metablog.ashx
+		https://blogs.technet.com/metablog.ashx
 		]]>
 		</postApiUrl>
 		<homepageUrlPattern>blogs\.technet\.com</homepageUrlPattern>

--- a/src/managed/OpenLiveWriter.CoreServices/ApplicationEnvironment.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/ApplicationEnvironment.cs
@@ -493,9 +493,9 @@ namespace OpenLiveWriter.CoreServices
             string userAgent;
             if (browserBased)
             {
-                // e.g. "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 7.0; Open Live Writer 1.0)"
+                // e.g. "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 7.0; Open Live Writer 1.0)"
                 userAgent = String.Format(CultureInfo.InvariantCulture,
-                                          "Mozilla/4.0 (compatible; MSIE {0}.{1}; Windows NT {2}.{3}; {4} 1.0)",
+                                          "Mozilla/5.0 (compatible; MSIE {0}.{1}; Windows NT {2}.{3}; {4} 1.0)",
                                           majorBrowserVersion,
                                           minorBrowserVersion,
                                           osVersion.Major,


### PR DESCRIPTION
## Summary
- Changes the Mozilla version in the browser-based user-agent string from `4.0` to `5.0`
- MSIE 9+ never identified as `Mozilla/4.0`, and the incorrect version was triggering anti-bot detection on some sites
- Applies the exact patch suggested in #950

## Test plan
- [ ] Verify the user-agent string emitted by the application now starts with `Mozilla/5.0`
- [ ] Confirm blog publishing works correctly with the updated user-agent
- [ ] Check that sites which previously triggered anti-bot warnings now work

Fixes #950