### PR TITLE
Fix StaticSiteItemFrontMatter serialization tests for cross-platform line endings

### DIFF
--- a/src/managed/OpenLiveWriter.Tests/BlogClient/Clients/StaticSite/StaticSiteItemFrontMatterTests.cs
+++ b/src/managed/OpenLiveWriter.Tests/BlogClient/Clients/StaticSite/StaticSiteItemFrontMatterTests.cs
@@ -75,8 +75,8 @@ layout: post
                 Layout = "post"
             };
 
-            // Assert
-            Assert.AreEqual(expected, fm.Serialize());
+            // Assert — normalize line endings for cross-platform compatibility
+            Assert.AreEqual(expected.Replace("\r\n", "\n"), fm.Serialize().Replace("\r\n", "\n"));
         }
 
 
@@ -101,8 +101,8 @@ tags:
                 Tags = new string[] {"hello", "world"}
             };
 
-            // Assert
-            Assert.AreEqual(expected, fm.Serialize());
+            // Assert — normalize line endings for cross-platform compatibility
+            Assert.AreEqual(expected.Replace("\r\n", "\n"), fm.Serialize().Replace("\r\n", "\n"));
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes the `Serialize_Basic` and `Serialize_WithTags` tests in `StaticSiteItemFrontMatterTests` which fail on Windows due to line ending differences.

## Changes

The tests used C# verbatim strings (`@""`) for expected values, which embed `\n` line endings from the source file. However, `StringWriter` (used by the YAML serializer in `Serialize()`) produces platform-native `\r\n` on Windows. This caused both Serialize tests to fail on Windows while passing on Unix.

Both assertions now normalize `\r\n` to `\n` in both expected and actual values before comparison.

## Test plan

- [x] `Serialize_Basic` passes on Windows
- [x] `Serialize_WithTags` passes on Windows
- [x] Full `OpenLiveWriter.Tests` suite: 46/46 passed
- [x] No regressions in other tests

Fixes #1019