### PR TITLE
Enable automatic redirect following in XmlRpcClient

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/XmlRpcClient.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/XmlRpcClient.cs
@@ -65,7 +65,7 @@ namespace OpenLiveWriter.CoreServices
                 response = HttpRequestHelper.SendRequest(_hostname, delegate (HttpWebRequest request)
                 {
                     request.Method = "POST";
-                    request.AllowAutoRedirect = false;
+                    request.AllowAutoRedirect = true;
                     request.ContentType = String.Format(CultureInfo.InvariantCulture, "{0};charset={1}", MimeHelper.TEXT_XML, encodingToUse.WebName);
                     if (_requestFilter != null)
                         _requestFilter(request);


### PR DESCRIPTION
## Description

XmlRpcClient explicitly disabled `AllowAutoRedirect`, causing blog connections to fail when servers return 301/302 redirects — common for HTTP to HTTPS migrations.

## Changes

Changed `request.AllowAutoRedirect = false` to `true` in `XmlRpcClient.cs`. The .NET framework handles redirect following automatically.

## Test plan

- [ ] Verify connecting to a blog that redirects HTTP→HTTPS succeeds
- [ ] Verify publishing to a blog with HTTPS redirect works
- [ ] Verify no regression for blogs without redirects

Fixes #872