### PR TITLE
Unwrap AggregateException in GoogleBloggerv3Client auth methods

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
@@ -265,7 +265,14 @@ namespace OpenLiveWriter.BlogClient.Clients
                 });
 
                 var loadTokenTask = flow.LoadTokenAsync(tc.Username, CancellationToken.None);
-                loadTokenTask.Wait();
+                try
+                {
+                    loadTokenTask.Wait();
+                }
+                catch (AggregateException ex)
+                {
+                    throw ex.InnerException ?? ex;
+                }
                 if (loadTokenTask.IsCompleted)
                 {
                     // We were able re-create the user credentials from the cache.
@@ -285,7 +292,14 @@ namespace OpenLiveWriter.BlogClient.Clients
 
                 // Start an OAuth flow to renew the credentials.
                 var authorizationTask = GetOAuth2AuthorizationAsync(tc.Username, CancellationToken.None);
-                authorizationTask.Wait();
+                try
+                {
+                    authorizationTask.Wait();
+                }
+                catch (AggregateException ex)
+                {
+                    throw ex.InnerException ?? ex;
+                }
                 if (authorizationTask.IsCompleted)
                 {
                     userCredential = authorizationTask.Result;
@@ -309,7 +323,14 @@ namespace OpenLiveWriter.BlogClient.Clients
             // Using the BloggerService automatically refreshes the access token, but we call the Picasa endpoint 
             // directly and therefore need to force refresh the access token on occasion.
             var userCredential = transientCredentials.Token as UserCredential;
-            userCredential?.RefreshTokenAsync(CancellationToken.None).Wait();
+            try
+            {
+                userCredential?.RefreshTokenAsync(CancellationToken.None).Wait();
+            }
+            catch (AggregateException ex)
+            {
+                throw ex.InnerException ?? ex;
+            }
         }
 
         private HttpRequestFilter CreateAuthorizationFilter()


### PR DESCRIPTION
## Description

When async Task operations fail during Google Blogger authentication, `.Wait()` throws `AggregateException` which wraps the real error. This produces confusing error messages for users.

## Changes

Wrapped three `.Wait()` calls in `VerifyAndRefreshCredentials` and `RefreshAccessToken` with try/catch blocks that unwrap `AggregateException` to its `InnerException`, surfacing the actual error (e.g., token expired, network error) instead of the generic wrapper.

## Test plan

- [ ] Verify Google Blogger authentication still works normally
- [ ] Verify expired token produces a clear error message instead of AggregateException
- [ ] Verify network errors during auth produce clear error messages

Fixes #827