### PR TITLE
Preserve clear attribute on BR tags in strict HTML thinning mode

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/HTML/LightWeightHTMLThinner2.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/HTML/LightWeightHTMLThinner2.cs
@@ -122,7 +122,7 @@ namespace OpenLiveWriter.CoreServices.HTML
             _tagSpecsStrict.Add("h5", P);
             _tagSpecsStrict.Add("h6", P);
 
-            _tagSpecsStrict.Add("br", BR);
+            _tagSpecsStrict.Add("br", new TagDesc(TagType.Empty, "clear"));
 
             _tagSpecsStrict.Add("blockquote", P);
 


### PR DESCRIPTION
## Description

When posts are reopened, the strict HTML thinner strips the `clear` attribute from `<br>` tags, removing intentional formatting breaks that create white space between sections.

## Changes

Added `clear` to the allowed attributes for `<br>` in strict mode (`_tagSpecsStrict`) in `LightWeightHTMLThinner2.cs`, matching the normal mode behavior which already allows it.

## Test plan

- [ ] Create a post with `<br clear="all">` breaks between sections
- [ ] Publish, close, and reopen the post
- [ ] Verify the clear breaks are preserved in the reopened post
- [ ] Verify no regression in HTML thinning for other tags

Fixes #879