### PR TITLE
Fall back to wp.getUsersBlogs when blogger.getUsersBlogs fails

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerCompatibleClient.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerCompatibleClient.cs
@@ -84,11 +84,27 @@ namespace OpenLiveWriter.BlogClient.Clients
 
         private BlogInfo[] GetUsersBlogs(string username, string password)
         {
-            // call method
-            XmlNode result = CallMethod("blogger.getUsersBlogs",
-                new XmlRpcString(APP_KEY),
-                new XmlRpcString(username),
-                new XmlRpcString(password, true));
+            // call method -- try blogger.getUsersBlogs first, but fall back to
+            // wp.getUsersBlogs if authentication fails. WordPress routes
+            // blogger.getUsersBlogs to wp_getUsersBlogs which only expects
+            // 2 parameters (username, password). The extra appKey parameter
+            // shifts the argument positions, causing WordPress to use appKey
+            // as the username and username as the password.
+            XmlNode result;
+            try
+            {
+                result = CallMethod("blogger.getUsersBlogs",
+                    new XmlRpcString(APP_KEY),
+                    new XmlRpcString(username),
+                    new XmlRpcString(password, true));
+            }
+            catch (BlogClientAuthenticationException)
+            {
+                // Retry with wp.getUsersBlogs (2 params, no appKey)
+                result = CallMethod("wp.getUsersBlogs",
+                    new XmlRpcString(username),
+                    new XmlRpcString(password, true));
+            }
 
             try
             {


### PR DESCRIPTION
## Description

WordPress routes `blogger.getUsersBlogs` to `wp_getUsersBlogs` internally, but the extra `appKey` parameter shifts the argument positions — WordPress interprets the appKey as the username and the username as the password, causing authentication to always fail.

## Changes

In `BloggerCompatibleClient.GetUsersBlogs()`, the `blogger.getUsersBlogs` call (3 params: appKey, username, password) is now wrapped in a try/catch. When it fails with `BlogClientAuthenticationException`, it retries with `wp.getUsersBlogs` (2 params: username, password) which is the format WordPress expects.

This matches the reporter's analysis in the issue — the second call with `wp.getUsersBlogs` always succeeds, but OLW was giving up after the first failure.

## Test plan

- [ ] Verify connecting to a WordPress blog succeeds
- [ ] Verify connecting to a non-WordPress Blogger-compatible blog still works
- [ ] Verify publishing to WordPress after reconnection works

Fixes #972