### PR TITLE
Sanitize Windows reserved device names in GetValidFileName

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/FileHelper.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/FileHelper.cs
@@ -374,6 +374,16 @@ namespace OpenLiveWriter.CoreServices
                     noExt = TrimFileAndReplaceWithGuidIfEmpty(noExt, null);
             }
 
+            // Sanitize Windows reserved device names (e.g. CON, PRN, AUX, NUL, COM1-9, LPT1-9)
+            // which cause ArgumentException when used with FileStream.
+            string[] reservedNames = { "CON", "PRN", "AUX", "NUL",
+                "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+                "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9" };
+            if (Array.Exists(reservedNames, n => string.Equals(n, noExt, StringComparison.OrdinalIgnoreCase)))
+            {
+                noExt = "_" + noExt;
+            }
+
             return noExt + Path.GetExtension(fileName);
         }
 


### PR DESCRIPTION
## Description

Post titles matching Windows reserved device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9) cause `ArgumentException: FileStream will not open Win32 devices` when saving, crashing the app and preventing draft saves.

## Changes

Added reserved device name detection to `FileHelper.GetValidFileName()`. If the base filename (without extension) matches a reserved name (case-insensitive), it is prefixed with an underscore to produce a valid filename (e.g., "CON" → "_CON.wpost").

## Test plan

- [ ] Create a post titled "CON" and save as draft — should save successfully as `_CON.wpost`
- [ ] Create posts with titles "PRN", "AUX", "NUL", "COM1", "LPT1" — all should save without error
- [ ] Create a post with a normal title — should be unaffected
- [ ] Publish a post titled "CON" — should succeed

Fixes #918