### PR TITLE
Update project URLs from openlivewriter.org to openlivewriter.com

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/GLink.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/GLink.cs
@@ -208,7 +208,7 @@ namespace OpenLiveWriter.CoreServices
                 return url;
             }
 
-            string glink = string.Format(CultureInfo.InvariantCulture, "http://openlivewriter.com/WriterRedirect/{0}", id);
+            string glink = string.Format(CultureInfo.InvariantCulture, "https://openlivewriter.com/WriterRedirect/{0}", id);
             return FixUpGLink(glink, null);
         }
 

--- a/src/managed/OpenLiveWriter.PostEditor/AboutForm.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/AboutForm.cs
@@ -248,7 +248,7 @@ namespace OpenLiveWriter.PostEditor
             this.labelWebsiteLink.Size = new System.Drawing.Size(173, 15);
             this.labelWebsiteLink.TabIndex = 13;
             this.labelWebsiteLink.TabStop = true;
-            this.labelWebsiteLink.Text = "http://www.openlivewriter.com/";
+            this.labelWebsiteLink.Text = "https://www.openlivewriter.com/";
             this.labelWebsiteLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.labelWebsiteLink_LinkClicked);
             // 
             // AboutForm


### PR DESCRIPTION
## Description

The old `openlivewriter.org` domain has expired. Two hardcoded URLs in the source code still reference it.

## Changes

- `AboutForm.cs`: Website link updated from `http://www.openlivewriter.org/` to `https://www.openlivewriter.com/`
- `GLink.cs`: Redirect base URL updated from `http://openlivewriter.org/WriterRedirect/` to `https://openlivewriter.com/WriterRedirect/`

Also upgraded both to HTTPS.

## Test plan

- [ ] Open About dialog — website link should point to openlivewriter.com
- [ ] Click the website link — should open the correct site
- [ ] Help links that use GLink redirects should resolve correctly

Fixes #927