### PR TITLE
Fix 'Show log file' link to handle missing log file gracefully

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/AboutForm.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/AboutForm.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
 using OpenLiveWriter.Controls;
@@ -301,7 +302,26 @@ namespace OpenLiveWriter.PostEditor
 
         private void lnkShowLogFile_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("explorer.exe", string.Format(CultureInfo.InvariantCulture, "/select,\"{0}\"", ApplicationEnvironment.LogFilePath));
+            string logPath = ApplicationEnvironment.LogFilePath;
+            if (File.Exists(logPath))
+            {
+                Process.Start("explorer.exe", string.Format(CultureInfo.InvariantCulture,
+                    "/select,\"{0}\"", logPath));
+            }
+            else
+            {
+                string dir = Path.GetDirectoryName(logPath);
+                if (Directory.Exists(dir))
+                {
+                    Process.Start("explorer.exe", string.Format(CultureInfo.InvariantCulture,
+                        "\"{0}\"", dir));
+                }
+                else
+                {
+                    Process.Start("explorer.exe", string.Format(CultureInfo.InvariantCulture,
+                        "\"{0}\"", ApplicationEnvironment.LocalApplicationDataDirectory));
+                }
+            }
         }
 
         private void labelWebsiteLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
## Description

The "Show log file" link in the About dialog opens "This PC" instead of the log file location. This happens because `explorer.exe /select,"path"` silently falls back to "This PC" when the target file doesn't exist yet (the log is only created on first write).

## Changes

Added a three-tier fallback in the `lnkShowLogFile_LinkClicked` handler in `AboutForm.cs`:
1. If the log file exists: highlight it in Explorer (original behavior)
2. If the file doesn't exist but its directory does: open the directory
3. If neither exists: open the app's local data directory

## Test plan

- [ ] Click "Show log file" before any logging has occurred — should open the log directory
- [ ] Click "Show log file" after some activity — should highlight the log file
- [ ] Verify the correct directory opens for both Store and desktop installs

Fixes #848