### PR TITLE
Set ReaderComments when posting to Google Blogger

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
@@ -99,6 +99,7 @@ namespace OpenLiveWriter.BlogClient.Clients
                 Permalink = post.Url,
                 Contents = post.Content,
                 DatePublished = post.Published.Value,
+                CommentPolicy = ConvertFromReaderComments(post.ReaderComments),
                 Categories = post.Labels?.Select(x => new BlogPostCategory(x)).ToArray() ?? new BlogPostCategory[0]
             };
         }
@@ -113,6 +114,35 @@ namespace OpenLiveWriter.BlogClient.Clients
             };
         }
 
+        private static string ConvertToReaderComments(BlogCommentPolicy commentPolicy)
+        {
+            switch (commentPolicy)
+            {
+                case BlogCommentPolicy.None:
+                    return "DONT_ALLOW_HIDE_EXISTING";
+                case BlogCommentPolicy.Closed:
+                    return "DONT_ALLOW_SHOW_EXISTING";
+                case BlogCommentPolicy.Open:
+                case BlogCommentPolicy.Unspecified:
+                default:
+                    return "ALLOW";
+            }
+        }
+
+        private static BlogCommentPolicy ConvertFromReaderComments(string readerComments)
+        {
+            switch (readerComments)
+            {
+                case "DONT_ALLOW_HIDE_EXISTING":
+                    return BlogCommentPolicy.None;
+                case "DONT_ALLOW_SHOW_EXISTING":
+                    return BlogCommentPolicy.Closed;
+                case "ALLOW":
+                default:
+                    return BlogCommentPolicy.Open;
+            }
+        }
+
         private static Post ConvertToGoogleBloggerPost(BlogPost post, IBlogClientOptions clientOptions)
         {
             var labels = post.Categories?.Select(x => x.Name).ToList();
@@ -123,6 +153,7 @@ namespace OpenLiveWriter.BlogClient.Clients
                 Content = post.Contents,
                 Labels = labels ?? new List<string>(),
                 Published = GetDatePublishedOverride(post, clientOptions),
+                ReaderComments = ConvertToReaderComments(post.CommentPolicy),
                 Title = post.Title,
             };
         }


### PR DESCRIPTION
## Description

Posts created via OLW have comments disabled by default on Blogger because the `ReaderComments` field is never set on the API request, causing Blogger to apply its own default (which may disable comments).

## Changes

- Added `ConvertToReaderComments()` — maps `BlogCommentPolicy` to Blogger API strings (`ALLOW`, `DONT_ALLOW_SHOW_EXISTING`, `DONT_ALLOW_HIDE_EXISTING`)
- Added `ConvertFromReaderComments()` — maps Blogger API strings back to `BlogCommentPolicy` for round-tripping
- `ConvertToGoogleBloggerPost()` now sets `ReaderComments` — defaults to `ALLOW` when unspecified, matching historical behavior
- `ConvertToBlogPost()` now reads `ReaderComments` back into `CommentPolicy`

## Test plan

- [ ] Publish a new post to Blogger — verify comments are enabled by default
- [ ] Edit an existing post with comments disabled — verify the setting is preserved
- [ ] Explicitly disable comments on a post in OLW — verify comments are disabled on Blogger

Fixes #859