### PR TITLE
Handle corrupted post files gracefully during startup recovery

### DIFF
--- a/src/managed/OpenLiveWriter/ApplicationLauncher.cs
+++ b/src/managed/OpenLiveWriter/ApplicationLauncher.cs
@@ -104,7 +104,14 @@ namespace OpenLiveWriter
                     case AutoRecoverPromptResult.Recover:
                         foreach (string autoSavedPost in autoSavedPostFiles)
                         {
-                            ExecutePostEditorFile(autoSavedPost, splashScreen);
+                            try
+                            {
+                                ExecutePostEditorFile(autoSavedPost, splashScreen);
+                            }
+                            catch (Exception ex)
+                            {
+                                Trace.WriteLine("Failed to recover post: " + autoSavedPost + " - " + ex.Message);
+                            }
                         }
                         return true;
                     case AutoRecoverPromptResult.Discard:


### PR DESCRIPTION
## Description

A single corrupted `.wpost` file in the auto-recovery folder causes the entire application to crash on startup. The `RecoverPosts()` loop calls `ExecutePostEditorFile()` with no error handling, so one bad file prevents all other posts from being recovered.

## Changes

Wrapped the `ExecutePostEditorFile()` call in a try/catch within the recovery loop in `ApplicationLauncher.cs`. Corrupted files are skipped with a trace warning, allowing remaining posts to be recovered normally.

## Test plan

- [ ] Place a corrupted `.wpost` file alongside valid ones in the recovery folder
- [ ] Launch OLW — should start successfully and recover the valid posts
- [ ] Verify the trace log contains a warning about the corrupted file

Fixes #819