### PR TITLE
Fix dead CLA link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To contribute code to the project simply:
   2. Create a specific topic branch, add a nice feature or fix your bug
   3. Send a Pull Request to spread the fun!
 
-If you haven't already, please sign the [.NET Foundation CLA](http://cla2.dotnetfoundation.org) to give us 
+If you haven't already, please sign the [.NET Foundation CLA](https://cla.dotnetfoundation.org/) to give us 
 permission to include your contributions in the next release of Open Live Writer.
 
 If you would like to discuss a change you are thinking of doing before you start work on it then feel free to raise an


### PR DESCRIPTION
## Description

The CLA link in CONTRIBUTING.md points to `http://cla2.dotnetfoundation.org` which no longer exists.

## Changes

Updated to `https://cla.dotnetfoundation.org/` with HTTPS.

Fixes #769