### PR TITLE
Handle IOException when opening settings file

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/Settings/XmlSettingsPersister.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/Settings/XmlSettingsPersister.cs
@@ -193,7 +193,27 @@ namespace OpenLiveWriter.CoreServices.Settings
 
         public static XmlFileSettingsPersister Open(string filename)
         {
-            Stream s = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            Stream s;
+            try
+            {
+                s = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            }
+            catch (IOException)
+            {
+                // File may be transiently locked by another process; retry once after a short delay
+                try
+                {
+                    Thread.Sleep(100);
+                    s = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                }
+                catch (IOException ex)
+                {
+                    // Still locked — fall back to empty in-memory settings so the app can start
+                    Trace.WriteLine("Unable to open settings file, using empty settings: " + ex.Message);
+                    return new XmlFileSettingsPersister(new MemoryStream(), new Hashtable(), new Hashtable());
+                }
+            }
+
             if (s.Length == 0)
             {
                 return new XmlFileSettingsPersister(s, new Hashtable(), new Hashtable());


### PR DESCRIPTION
## Description

`XmlFileSettingsPersister.Open` throws `IOException` when the settings file is locked by another process (e.g., another OLW instance, antivirus scanning), crashing the app on startup.

## Changes

Wrapped the `FileStream` creation with IOException handling:
1. First attempt opens the file normally
2. On IOException, retries once after 100ms (handles transient locks)
3. If still locked, falls back to an in-memory `MemoryStream` with empty settings so the app can start

Settings won't persist to disk in the degraded fallback case, but the app remains functional rather than crashing.

## Test plan

- [ ] Normal startup with unlocked settings file works as before
- [ ] Startup with a locked settings file doesn't crash — app starts with defaults
- [ ] Settings persist normally when the file isn't locked

Fixes #785