### PR TITLE
Handle invalid URI in editor template path gracefully

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/PostHtmlEditingSettings.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/PostHtmlEditingSettings.cs
@@ -108,7 +108,16 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
                 {
                     string origPath = File.ReadAllText(templateHtmlFile + ".path");
                     string newPath = Path.Combine(Path.GetDirectoryName(templateHtmlFile), Path.GetFileName(origPath));
-                    string newUri = UrlHelper.SafeToAbsoluteUri(new Uri(newPath));
+                    Uri pathUri;
+                    string newUri;
+                    if (Uri.TryCreate(newPath, UriKind.Absolute, out pathUri))
+                    {
+                        newUri = UrlHelper.SafeToAbsoluteUri(pathUri);
+                    }
+                    else
+                    {
+                        newUri = newPath;
+                    }
                     templateHtml = templateHtml.Replace(origPath, newUri);
                 }
 


### PR DESCRIPTION
## Description

`GetEditorTemplateHtml` throws `ArgumentException` when the blog template `.path` file contains characters that are invalid in a URI. The `new Uri(newPath)` constructor crashes instead of handling the malformed path.

## Changes

Replaced `new Uri(newPath)` with `Uri.TryCreate()`. When the URI is invalid, the path is used as-is rather than throwing an exception.

## Test plan

- [ ] Blog with a valid template path renders correctly
- [ ] Blog with a malformed template path falls back gracefully instead of crashing

Fixes #766