### PR TITLE
Fix unhandled exception in Blogger login wizard

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/Configuration/Wizard/WeblogConfigurationWizardPanelGoogleBloggerAuthentication.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Configuration/Wizard/WeblogConfigurationWizardPanelGoogleBloggerAuthentication.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Windows.Forms;
 using Google.Apis.Auth.OAuth2;
@@ -46,35 +47,43 @@ namespace OpenLiveWriter.PostEditor.Configuration.Wizard
 
         private async void buttonLogin_Click(object sender, EventArgs e)
         {
-            buttonLogin.Enabled = false;
-
             try
             {
-                _cancellationTokenSource = new CancellationTokenSource();
-                _userCredentials = await GoogleBloggerv3Client.GetOAuth2AuthorizationAsync(_blogId, _cancellationTokenSource.Token);
-                _cancellationTokenSource = null;
+                buttonLogin.Enabled = false;
 
-                if (_userCredentials?.Token != null)
+                try
                 {
-                    // Leave the button disabled but let the user know they are signed in.
-                    buttonLogin.Text = Res.Get(StringId.CWGoogleBloggerSignInSuccess);
+                    _cancellationTokenSource = new CancellationTokenSource();
+                    _userCredentials = await GoogleBloggerv3Client.GetOAuth2AuthorizationAsync(_blogId, _cancellationTokenSource.Token);
+                    _cancellationTokenSource = null;
 
-                    // If this is the first time through the login flow, automatically click the 'Next' button on 
-                    // behalf of the user.
-                    if (_wizardController != null)
+                    if (_userCredentials?.Token != null)
                     {
-                        _wizardController.next();
-                        _wizardController = null;
+                        // Leave the button disabled but let the user know they are signed in.
+                        buttonLogin.Text = Res.Get(StringId.CWGoogleBloggerSignInSuccess);
+
+                        // If this is the first time through the login flow, automatically click the 'Next' button on
+                        // behalf of the user.
+                        if (_wizardController != null)
+                        {
+                            _wizardController.next();
+                            _wizardController = null;
+                        }
+                    }
+                }
+                finally
+                {
+                    if (_userCredentials?.Token == null)
+                    {
+                        // Let the user try again.
+                        buttonLogin.Enabled = true;
                     }
                 }
             }
-            finally
+            catch (Exception ex)
             {
-                if (_userCredentials?.Token == null)
-                {
-                    // Let the user try again.
-                    buttonLogin.Enabled = true;
-                }
+                Trace.Fail("Unexpected exception in Google Blogger login: " + ex.ToString());
+                buttonLogin.Enabled = true;
             }
         }
         


### PR DESCRIPTION
## Description

The `buttonLogin_Click` async void handler in the Blogger authentication wizard had incomplete error handling. The existing try-catch covered the OAuth call but not the subsequent wizard navigation (`_wizardController.next()`), so exceptions from that call propagated as unhandled and crashed the app.

## Changes

Wrapped the entire method body in an outer try-catch. The inner try-finally (for OAuth + button re-enable) is preserved. The outer catch logs via `Trace.Fail` (matching the pattern used elsewhere in the wizard) and re-enables the login button so the user can retry.

## Test plan

- [ ] Successful Blogger login proceeds through the wizard normally
- [ ] Failed OAuth shows error without crashing
- [ ] Network errors during wizard navigation don't crash the app

Fixes #800