### PR TITLE
Handle COMException when setting outerHTML on param elements

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/HTML/HTMLDocumentHelper.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/HTML/HTMLDocumentHelper.cs
@@ -983,8 +983,15 @@ namespace OpenLiveWriter.CoreServices
                     if (relativePath == string.Empty)
                         relativePath = "\"\"";
 
-                    param.outerHTML =
-                        param.outerHTML.Replace(relativePath, UrlHelper.EscapeRelativeURL(baseUrl, relativePath));
+                    try
+                    {
+                        param.outerHTML =
+                            param.outerHTML.Replace(relativePath, UrlHelper.EscapeRelativeURL(baseUrl, relativePath));
+                    }
+                    catch (COMException)
+                    {
+                        // Element may not support outerHTML assignment; skip it
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

`EscapeNonResourceRelativePaths` in `HTMLDocumentHelper.cs` crashes with COMException (HRESULT 0x800A0259 - "Invalid target element for this operation") when iterating param elements that don't support `outerHTML` assignment.

## Changes

Wrapped the `param.outerHTML` assignment in a try-catch for `COMException`. Elements that don't support the operation are silently skipped since this is a best-effort URL escaping pass.

## Test plan

- [ ] Posts with param elements (e.g., embedded objects) save without crashing
- [ ] URL escaping still works for param elements that support outerHTML
- [ ] No regression in normal post editing

Fixes #815