### PR TITLE
Support pasting Bitmap clipboard images from Snip & Sketch

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/DataObject/ImageData.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/DataObject/ImageData.cs
@@ -19,7 +19,9 @@ namespace OpenLiveWriter.CoreServices
         /// <returns>The ImageData, null if no ImageData could be created</returns>
         public static ImageData Create(IDataObject iDataObject)
         {
-            if (!OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.Dib) && !OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.EnhancedMetafile))
+            if (!OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.Dib) &&
+                !OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.EnhancedMetafile) &&
+                !OleDataObjectHelper.GetDataPresentSafe(iDataObject, DataFormats.Bitmap))
                 return null;
             else
                 return new ImageData(iDataObject);


### PR DESCRIPTION
## Description

Pasting images from Snip & Sketch (and other modern Windows screenshot tools) does nothing because OLW only accepted DIB and EnhancedMetafile clipboard formats. Snip & Sketch puts Bitmap data on the clipboard instead.

## Changes

Added `DataFormats.Bitmap` to the accepted clipboard formats in `ImageData.Create()`. The class already had a `Bitmap` property that correctly reads Bitmap data — only the gate check in `Create()` was blocking it.

## Test plan

- [ ] Paste an image from Snip & Sketch into a post — should work
- [ ] Paste an image from the Photos app — should still work (uses DIB)
- [ ] Paste an image from Paint/screenshot — should still work
- [ ] Copy/paste from web browser — should still work

Fixes #779