### PR TITLE
Preserve published date when editing existing posts

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Blog.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Blog.cs
@@ -559,6 +559,8 @@ namespace OpenLiveWriter.BlogClient
             // determine the date-published based on whether there was an override
             if (post.HasDatePublishedOverride)
                 result.DatePublished = post.DatePublishedOverride;
+            else if (post.DatePublished != DateTime.MinValue && post.DatePublished != DateTime.MaxValue)
+                result.DatePublished = post.DatePublished;
             else
                 result.DatePublished = DateTimeHelper.UtcNow;
 


### PR DESCRIPTION
## Description

When editing an existing post (e.g., one originally created with Windows Live Writer), the published date gets reset to "now" instead of preserving the original date. This causes old posts to appear as newly published.

## Changes

In `Blog.EditPost()`, added a check to preserve `post.DatePublished` when it's a valid date and no explicit date override is set. The priority is:

1. User-specified date override (unchanged)
2. **New:** Existing published date from the post
3. Fall back to current time only if no valid date exists

`Blog.NewPost()` is intentionally unchanged — new posts correctly default to "now" when no override is set.

## Test plan

- [ ] Edit an existing post and publish — original date should be preserved
- [ ] Edit a post and set a date override — override should be used
- [ ] Create a new post without a date override — should publish as "now"
- [ ] Edit a post originally created with Windows Live Writer — date should not change

Fixes #733