### PR TITLE
Set proper Accept header for AtomPub requests

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerAtomClient.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/BloggerAtomClient.cs
@@ -662,9 +662,9 @@ namespace OpenLiveWriter.BlogClient.Clients
 
         private bool AuthorizeRequest(HttpWebRequest request, string serviceName)
         {
-            // This line is required to avoid Error 500 from non-beta Blogger blogs.
-            // According to Pete Hopkins it is "something with .NET".
-            request.Accept = "*/*";
+            // Use the proper Atom content type for content negotiation.
+            // AtomPub endpoints may serve different formats based on Accept header.
+            request.Accept = "application/atom+xml";
 
             TransientCredentials transientCredentials = Login();
             GDataCredentials cred = GDataCredentials.FromCredentials(transientCredentials);

--- a/src/managed/OpenLiveWriter.BlogClient/Clients/XmlRestRequestHelper.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/XmlRestRequestHelper.cs
@@ -68,7 +68,14 @@ namespace OpenLiveWriter.BlogClient.Clients
             }
 
             RedirectHelper.SimpleRequest simpleRequest = new RedirectHelper.SimpleRequest(method, filter);
-            HttpWebResponse response = RedirectHelper.GetResponse(absUri, new RedirectHelper.RequestFactory(simpleRequest.Create));
+            HttpWebResponse response = RedirectHelper.GetResponse(absUri, new RedirectHelper.RequestFactory((requestUri) =>
+            {
+                var req = simpleRequest.Create(requestUri);
+                // Override the default */* Accept header for XML REST requests.
+                // AtomPub endpoints require application/atom+xml for content negotiation.
+                req.Accept = "application/atom+xml";
+                return req;
+            }));
             try
             {
                 uri = response.ResponseUri;
@@ -196,6 +203,9 @@ namespace OpenLiveWriter.BlogClient.Clients
             {
                 HttpWebRequest request = HttpRequestHelper.CreateHttpWebRequest(uri, true);
                 request.Method = _method;
+                // Override the default */* Accept header for XML REST requests.
+                // AtomPub endpoints require application/atom+xml for content negotiation.
+                request.Accept = "application/atom+xml";
                 //			    request.KeepAlive = true;
                 //			    request.Pipelined = true;
                 if (_etag != null && _etag != "")


### PR DESCRIPTION
## Description

AtomPub requests were sending `Accept: */*` which breaks content negotiation on servers that serve different formats based on the Accept header.

## Changes

- `XmlRestRequestHelper.cs`: Set `Accept: application/atom+xml` in both `SimpleRequest` (GET/DELETE) and `SendFactory.Create` (PUT/POST) methods
- `BloggerAtomClient.cs`: Changed `Accept: */*` to `Accept: application/atom+xml` in the `AuthorizeRequest` method

The general `*/*` default in `HttpRequestHelper.cs` is intentionally unchanged (it exists for WordPress Bad Behavior plugin compatibility and applies to non-AtomPub requests).

## Test plan

- [ ] Publish to an AtomPub blog — should work with proper Accept header
- [ ] Retrieve posts from AtomPub endpoint — should return Atom XML
- [ ] Blogger operations should continue to work

Fixes #749