### PR TITLE
Handle malformed smart content element IDs gracefully

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/Sidebar/ContentSourceSidebarControl.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/Sidebar/ContentSourceSidebarControl.cs
@@ -100,7 +100,15 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing.Sidebar
                     }
                 }
 
-                ContentSourceManager.ParseContainingElementId(_selectedElement.id, out _contentSourceId, out _contentItemId);
+                try
+                {
+                    ContentSourceManager.ParseContainingElementId(_selectedElement.id, out _contentSourceId, out _contentItemId);
+                }
+                catch (ArgumentException)
+                {
+                    Trace.Fail("Malformed smart content element id: " + _selectedElement.id);
+                    return;
+                }
 
                 SmartContentEditor editor = (SmartContentEditor)_contentSourceControls[_contentSourceId];
                 ContentSourceInfo contentSource = _contentSourceContext.FindContentSource(_contentSourceId);


### PR DESCRIPTION
## Description

Pasting malformed smart content causes an unhandled `ArgumentException` in `ParseContainingElementId` that propagates through the selection change handler and crashes the app.

## Changes

Wrapped the `ParseContainingElementId` call in `ContentSourceSidebarControl.UpdateView` with a try-catch for `ArgumentException`. Malformed element IDs are logged via `Trace.Fail` and the method returns early instead of crashing.

## Test plan

- [ ] Paste normal smart content (e.g., map, video) — should work as before
- [ ] Paste malformed HTML with broken smart content markers — should not crash

Fixes #703