### PR TITLE
Handle GDI+ threading exception in emoticons gallery

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/Emoticons/EmoticonsGalleryCommand.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Emoticons/EmoticonsGalleryCommand.cs
@@ -43,7 +43,18 @@ namespace OpenLiveWriter.PostEditor.Emoticons
                     Items.Add(new GalleryItem(emoticon.Label, emoticon.Bitmap, emoticon, PopularIndex));
 
                     // WinLive 122017: Build up a cache of gallery items we can use to represent recently used emoticons.
-                    recentEmoticonsGalleryItems.Add(new GalleryItem(emoticon.Label, (Bitmap)emoticon.Bitmap.Clone(), emoticon, RecentIndex));
+                    // Bitmap.Clone() can throw InvalidOperationException when the source bitmap
+                    // is in use on another thread. Fall back to the original bitmap reference.
+                    Bitmap recentBitmap;
+                    try
+                    {
+                        recentBitmap = (Bitmap)emoticon.Bitmap.Clone();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        recentBitmap = emoticon.Bitmap;
+                    }
+                    recentEmoticonsGalleryItems.Add(new GalleryItem(emoticon.Label, recentBitmap, emoticon, RecentIndex));
                 }
             }
 


### PR DESCRIPTION
## Description

The emoticons gallery crashes with `InvalidOperationException: Object is currently in use elsewhere` when `Bitmap.Clone()` is called while the source bitmap is being accessed from another thread.

## Changes

Wrapped `Bitmap.Clone()` in `EmoticonsGalleryCommand.LoadItems` with a try-catch for `InvalidOperationException`. On failure, falls back to using the original bitmap reference.

## Test plan

- [ ] Open the emoticons gallery — should display without crashing
- [ ] Insert an emoticon — should work normally

Fixes #736