### PR TITLE
Add null checks in image reference fixer callback

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/RecentPostSynchronizer.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/RecentPostSynchronizer.cs
@@ -369,11 +369,24 @@ namespace OpenLiveWriter.PostEditor
             }
             public void ReferenceFixedCallback(string oldReference, string newReference)
             {
-                ISupportingFile file = _editingContext.SupportingFileService.GetFileByUri(new Uri(newReference));
+                Uri newUri;
+                try
+                {
+                    newUri = new Uri(newReference);
+                }
+                catch (UriFormatException)
+                {
+                    return;
+                }
+
+                ISupportingFile file = _editingContext.SupportingFileService.GetFileByUri(newUri);
                 if (file != null)
                 {
                     foreach (BlogPostImageData imageData in _editingContext.ImageDataList)
                     {
+                        if (imageData.InlineImageFile == null || imageData.InlineImageFile.SupportingFile == null)
+                            continue;
+
                         // We can no longer trust the target settings for this file, so we must remove them
                         // this means the first time the object is clicked it will read the settings from the DOM
                         if (file.FileId == imageData.InlineImageFile.SupportingFile.FileId)


### PR DESCRIPTION
## Description

`ReferenceFixedCallback` in `RecentPostSynchronizer.ContextImageReferenceFixer` crashes with `NullReferenceException` when `GetFileByUri` returns null or when image data properties in the chain are null.

## Changes

Added defensive null checks for `imageData.InlineImageFile` and `imageData.InlineImageFile.SupportingFile` in the foreach loop, and wrapped `new Uri(newReference)` in a try-catch for `UriFormatException`.

## Test plan

- [ ] Sync a recent post with images — should work normally
- [ ] Sync a post with broken/missing image references — should not crash

Fixes #648