### PR TITLE
Suppress COMException in TableEditor.SelectionPreserver.Dispose

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/Tables/TableEditor.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/Tables/TableEditor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Drawing;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Collections;
 using System.Windows.Forms;
@@ -1284,7 +1285,20 @@ namespace OpenLiveWriter.PostEditor.Tables
 
             public void Dispose()
             {
-                _preservedMarkupRange.ToTextRange().select();
+                try
+                {
+                    _preservedMarkupRange.ToTextRange().select();
+                }
+                catch (COMException)
+                {
+                    // Suppress COM errors during selection restoration.
+                    // The underlying COM object may no longer be valid after
+                    // table row operations. Dispose should never throw.
+                }
+                catch (InvalidOperationException)
+                {
+                    // Suppress in case the markup range is in an invalid state.
+                }
             }
 
             private MarkupRange _preservedMarkupRange = null;


### PR DESCRIPTION
## Description

Moving table rows crashes with `COMException` in `SelectionPreserver.Dispose` when the markup range is no longer valid after the row operation. `Dispose` should never propagate exceptions.

## Changes

Wrapped the `Dispose` body in a try-catch that suppresses `COMException` and `InvalidOperationException` during selection restoration cleanup.

## Test plan

- [ ] Move table rows up/down — should work without crashing
- [ ] Edit tables normally — no regression

Fixes #750