### PR TITLE
Handle malformed URLs in createUniqueVarNameForFileUrl

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/BlogPostHtmlSourceEditorControl.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/BlogPostHtmlSourceEditorControl.cs
@@ -603,7 +603,11 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
         /// <returns></returns>
         private string createUniqueVarNameForFileUrl(string url)
         {
-            string localPath = new Uri(url).LocalPath;
+            Uri uri;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
+                return url;
+
+            string localPath = uri.LocalPath;
             string fileName = Path.GetFileNameWithoutExtension(localPath);
             string ext = Path.GetExtension(localPath);
             string varName = String.Format(CultureInfo.InvariantCulture, "${0}{1}", fileName, ext);


### PR DESCRIPTION
## Description

Switching between source and visual editing modes crashes with `ArgumentException` when HTML contains malformed URLs. The `Uri` constructor in `createUniqueVarNameForFileUrl` doesn't handle invalid URIs.

## Changes

Replaced `new Uri(url)` with `Uri.TryCreate` validation. Malformed URLs are returned unchanged instead of crashing.

## Test plan

- [ ] Switch between Source and Edit views with normal content — should work
- [ ] Switch views with HTML containing malformed URLs — should not crash

Fixes #717