### PR TITLE
Fix file locking crash in XmlFileSettingsPersister

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -103,7 +103,7 @@ else
 
 if (-Not (Test-Path env:OLW_CONFIG))
 {
-    "Environment variable OWL_CONFIG not set, setting to 'Debug'"
+    "Environment variable OLW_CONFIG not set, setting to 'Debug'"
 	$env:OLW_CONFIG = 'Debug'
 }
 

--- a/src/managed/OpenLiveWriter.CoreServices/Settings/XmlSettingsPersister.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/Settings/XmlSettingsPersister.cs
@@ -166,14 +166,19 @@ namespace OpenLiveWriter.CoreServices.Settings
 
     public class XmlFileSettingsPersister : XmlSettingsPersister
     {
-        private readonly Stream stream;
+        /// <summary>
+        /// Path to the backing XML file, or null when operating in memory-only mode.
+        /// The file is opened only for the duration of each read/write operation
+        /// so that multiple processes can coexist without "file in use" crashes.
+        /// </summary>
+        private readonly string filename;
         private readonly object syncRoot = new object();
         private int batchUpdateRefCount = 0;
 
-        private XmlFileSettingsPersister(Stream stream, Hashtable values, Hashtable subsettings)
+        private XmlFileSettingsPersister(string filename, Hashtable values, Hashtable subsettings)
             : base(values, subsettings)
         {
-            this.stream = stream;
+            this.filename = filename;
         }
 
         protected internal override object SyncRoot
@@ -183,20 +188,15 @@ namespace OpenLiveWriter.CoreServices.Settings
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                stream.Dispose();
-            }
+            // No long-lived stream to dispose; kept for interface compatibility
             base.Dispose(false);
-
         }
 
         public static XmlFileSettingsPersister Open(string filename)
         {
-            Stream s;
             try
             {
-                s = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                return ReadSettingsFromFile(filename);
             }
             catch (IOException)
             {
@@ -204,25 +204,31 @@ namespace OpenLiveWriter.CoreServices.Settings
                 try
                 {
                     Thread.Sleep(100);
-                    s = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+                    return ReadSettingsFromFile(filename);
                 }
                 catch (IOException ex)
                 {
                     // Still locked — fall back to empty in-memory settings so the app can start
                     Trace.WriteLine("Unable to open settings file, using empty settings: " + ex.Message);
-                    return new XmlFileSettingsPersister(new MemoryStream(), new Hashtable(), new Hashtable());
+                    return new XmlFileSettingsPersister(null, new Hashtable(), new Hashtable());
                 }
             }
+        }
 
-            if (s.Length == 0)
+        private static XmlFileSettingsPersister ReadSettingsFromFile(string filename)
+        {
+            using (FileStream s = new FileStream(filename, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite))
             {
-                return new XmlFileSettingsPersister(s, new Hashtable(), new Hashtable());
-            }
-            else
-            {
-                Hashtable values, subsettings;
-                Parse(s, out values, out subsettings);
-                return new XmlFileSettingsPersister(s, values, subsettings);
+                if (s.Length == 0)
+                {
+                    return new XmlFileSettingsPersister(filename, new Hashtable(), new Hashtable());
+                }
+                else
+                {
+                    Hashtable values, subsettings;
+                    Parse(s, out values, out subsettings);
+                    return new XmlFileSettingsPersister(filename, values, subsettings);
+                }
             }
         }
 
@@ -557,15 +563,28 @@ namespace OpenLiveWriter.CoreServices.Settings
                 if (batchUpdateRefCount > 0)
                     return;
 
+                // In memory-only mode (fallback from failed file open), skip writing
+                if (filename == null)
+                    return;
+
                 XmlDocument xmlDoc = new XmlDocument();
                 System.Xml.XmlElement settings = xmlDoc.CreateElement("settings");
                 xmlDoc.AppendChild(settings);
                 ToXml(settings, values, subsettings);
 
-                stream.Position = 0;
-                stream.SetLength(0);
-                xmlDoc.Save(stream);
-                stream.Flush();
+                try
+                {
+                    using (FileStream s = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Read))
+                    {
+                        xmlDoc.Save(s);
+                        s.Flush();
+                    }
+                }
+                catch (IOException ex)
+                {
+                    // If another process has the file locked, log but don't crash
+                    Trace.WriteLine("Unable to persist settings: " + ex.Message);
+                }
             }
         }
 

--- a/src/managed/OpenLiveWriter.UnitTest/CoreServices/XmlFileSettingsPersisterTest.cs
+++ b/src/managed/OpenLiveWriter.UnitTest/CoreServices/XmlFileSettingsPersisterTest.cs
@@ -1,0 +1,184 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenLiveWriter.CoreServices.Settings;
+
+namespace OpenLiveWriter.UnitTest.CoreServices
+{
+    [TestClass]
+    public class XmlFileSettingsPersisterTest
+    {
+        private string _tempDir;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "OLW_Test_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            try { Directory.Delete(_tempDir, true); }
+            catch (IOException) { }
+        }
+
+        private string TempFile(string name = "settings.xml")
+        {
+            return Path.Combine(_tempDir, name);
+        }
+
+        [TestMethod]
+        public void Open_NewFile_ReturnsEmptySettings()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                Assert.AreEqual(0, persister.GetNames().Length);
+                Assert.AreEqual(0, persister.GetSubSettings().Length);
+            }
+        }
+
+        [TestMethod]
+        public void SetAndGet_RoundTrips()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                persister.Set("key1", "value1");
+                persister.Set("key2", 42);
+
+                Assert.AreEqual("value1", persister.Get("key1"));
+                Assert.AreEqual(42, persister.Get("key2"));
+            }
+        }
+
+        [TestMethod]
+        public void Persist_SurvivesReopen()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                persister.Set("name", "test");
+                persister.Set("count", 7);
+            }
+
+            // Re-open and verify data was persisted
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                Assert.AreEqual("test", persister.Get("name"));
+                Assert.AreEqual(7, persister.Get("count"));
+            }
+        }
+
+        [TestMethod]
+        public void FileNotLockedAfterOpen()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                persister.Set("key", "value");
+
+                // The file should not be locked — another writer should be able to open it
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+                {
+                    Assert.IsTrue(fs.Length > 0, "File should have content after Set");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MultipleInstances_CanCoexist()
+        {
+            string path = TempFile();
+
+            // Open two persisters on the same file simultaneously
+            using (var persister1 = XmlFileSettingsPersister.Open(path))
+            {
+                persister1.Set("from", "instance1");
+
+                // Second instance should be able to open the same file
+                using (var persister2 = XmlFileSettingsPersister.Open(path))
+                {
+                    // Instance 2 should see data written by instance 1
+                    Assert.AreEqual("instance1", persister2.Get("from"));
+
+                    // Instance 2 should be able to write
+                    persister2.Set("from", "instance2");
+                }
+
+                // Instance 1 can still write without crashing
+                persister1.Set("extra", "data");
+            }
+        }
+
+        [TestMethod]
+        public void SubSettings_RoundTrip()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                using (var sub = persister.GetSubSettings("child"))
+                {
+                    sub.Set("nested", "value");
+                }
+            }
+
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                Assert.IsTrue(persister.HasSubSettings("child"));
+                using (var sub = persister.GetSubSettings("child"))
+                {
+                    Assert.AreEqual("value", sub.Get("nested"));
+                }
+            }
+        }
+
+        [TestMethod]
+        public void BatchUpdate_DefersWriteUntilEnd()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                using (persister.BatchUpdate())
+                {
+                    persister.Set("a", "1");
+                    persister.Set("b", "2");
+                    persister.Set("c", "3");
+                    // File may or may not have been written yet (batch defers)
+                }
+
+                // After batch completes, all values should be persisted
+                Assert.AreEqual("1", persister.Get("a"));
+                Assert.AreEqual("2", persister.Get("b"));
+                Assert.AreEqual("3", persister.Get("c"));
+            }
+
+            // Verify they survived to disk
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                Assert.AreEqual("1", persister.Get("a"));
+                Assert.AreEqual("2", persister.Get("b"));
+                Assert.AreEqual("3", persister.Get("c"));
+            }
+        }
+
+        [TestMethod]
+        public void Unset_RemovesValue()
+        {
+            string path = TempFile();
+            using (var persister = XmlFileSettingsPersister.Open(path))
+            {
+                persister.Set("key", "value");
+                Assert.AreEqual("value", persister.Get("key"));
+
+                persister.Unset("key");
+                Assert.IsNull(persister.Get("key"));
+            }
+        }
+    }
+}

--- a/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
+++ b/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
@@ -104,6 +104,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CoreServices\XmlFileSettingsPersisterTest.cs" />
     <Compile Include="HtmlEditor\WordCounterTests\HebrewTextWordCount.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

`XmlFileSettingsPersister` held a `FileStream` open for the entire object lifetime with `FileShare.Read`, preventing other OLW instances from writing to the same settings file and causing "file being used by another process" crashes.

## Changes

Replaced the long-lived FileStream with open-read-close / open-write-close patterns:
- `Open()` reads file contents into memory, then closes the stream immediately
- `Persist()` opens a new stream, writes, and closes it immediately
- `IOException` during persist is caught and logged instead of crashing
- File is no longer locked between operations

## Tests (8 tests)

- Open new file returns empty settings
- Set/Get round-trips
- Data survives close and reopen
- File is not locked after Open
- Multiple instances can coexist simultaneously
- SubSettings round-trip
- BatchUpdate defers writes
- Unset removes values

Also fixes `OWL_CONFIG` typo in build.ps1.

Fixes #621