### PR TITLE
Validate Visual Studio location before building MSBuild path

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -36,6 +36,14 @@ if (Test-Path $vswherePath) {
     $visualStudioLocation = (Get-VSSetupInstance | Select-VSSetupInstance -Latest).InstallationPath
 }
 
+if (-Not $visualStudioLocation)
+{
+    "Visual Studio installation not found."
+    "Ensure Visual Studio (2017 or later) or Build Tools for Visual Studio is installed."
+    "These can be downloaded from https://visualstudio.microsoft.com/downloads/"
+    exit 100
+}
+
 # Try "Current" path first (VS2019/VS2022/VS2026+), then fall back to versioned paths
 $msBuildExe = $visualStudioLocation + "\MSBuild\Current\Bin\msbuild.exe"
 IF (-Not (Test-Path -LiteralPath "$msBuildExe" -PathType Leaf))


### PR DESCRIPTION
## Description

If `vswhere.exe` is not found and the `VSSetup` module fails to install, `$visualStudioLocation` remains `$null`. Subsequent path concatenation produces malformed paths like `\MSBuild\Current\Bin\msbuild.exe`, leading to confusing error messages.

## Changes

Added a null check after the VS discovery block. If no Visual Studio installation is found, the script exits early with a clear error message instead of falling through to a confusing "MSBuild not found" error with a mangled path.

## Test plan

- [ ] Build on a machine with VS installed — should work as before
- [ ] Build on a machine without VS — should show the new clear error message