### PR TITLE
Handle COMException in WinSpellingChecker.CheckWord

### DIFF
--- a/src/managed/OpenLiveWriter.SpellChecker/WinSpellingChecker.cs
+++ b/src/managed/OpenLiveWriter.SpellChecker/WinSpellingChecker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace OpenLiveWriter.SpellChecker
 {
@@ -45,7 +46,20 @@ namespace OpenLiveWriter.SpellChecker
                 return SpellCheckResult.Correct;
             }
 
-            PlatformSpellCheck.SpellingError spellerStatus = _speller.Check(word).FirstOrDefault();
+            PlatformSpellCheck.SpellingError spellerStatus;
+            try
+            {
+                spellerStatus = _speller.Check(word).FirstOrDefault();
+            }
+            catch (COMException)
+            {
+                // The Windows spell-check COM API can throw COMException when
+                // the document is being modified during background spell-checking.
+                // Treat as correct rather than crashing.
+                offset = 0;
+                length = 0;
+                return SpellCheckResult.Correct;
+            }
 
             if (spellerStatus == null)
             {
@@ -120,9 +134,18 @@ namespace OpenLiveWriter.SpellChecker
             CheckInitialized();
             List<SpellingSuggestion> list = new List<SpellingSuggestion>();
 
-            foreach (string suggestion in _speller.Suggestions(word).Take(maxSuggestions))
+            try
             {
-                list.Add(new SpellingSuggestion(suggestion, 1));
+                foreach (string suggestion in _speller.Suggestions(word).Take(maxSuggestions))
+                {
+                    list.Add(new SpellingSuggestion(suggestion, 1));
+                }
+            }
+            catch (COMException)
+            {
+                // The Windows spell-check COM API can throw COMException when
+                // the document is being modified during background spell-checking.
+                // Return whatever suggestions we have so far rather than crashing.
             }
 
             return list.ToArray();


### PR DESCRIPTION
## Description

The Windows spell-check COM API throws COMException when the document is being modified during background spell-checking, crashing the app.

## Changes

Wrapped COM calls in `CheckWord` and `Suggest` with try-catch for `COMException`. On failure, `CheckWord` returns correct (skip the word) and `Suggest` returns whatever suggestions were collected. SpellingHighlighter already has existing COMException handling further up the stack.

## Test plan

- [ ] Type rapidly while spell-checking is active — should not crash
- [ ] Spell-check continues to highlight misspelled words normally

Fixes #741, Fixes #664, Fixes #614