### PR TITLE
Handle COMException in HtmlEditorSelection operations

### DIFF
--- a/src/managed/OpenLiveWriter.HtmlEditor/HtmlEditorControl.cs
+++ b/src/managed/OpenLiveWriter.HtmlEditor/HtmlEditorControl.cs
@@ -3223,8 +3223,15 @@ namespace OpenLiveWriter.HtmlEditor
 
         public virtual void EmptySelection()
         {
-            if (HTMLDocument.readyState == "complete" && HTMLDocument.selection != null)
-                HTMLDocument.selection.empty();
+            try
+            {
+                if (HTMLDocument.readyState == "complete" && HTMLDocument.selection != null)
+                    HTMLDocument.selection.empty();
+            }
+            catch (COMException ex)
+            {
+                Trace.WriteLine("COMException emptying selection (the DOM may be in a transitional state): " + ex.Message);
+            }
         }
 
         public void InsertHtml(string html, bool moveSelectionRight)

--- a/src/managed/OpenLiveWriter.HtmlEditor/HtmlEditorSelection.cs
+++ b/src/managed/OpenLiveWriter.HtmlEditor/HtmlEditorSelection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using mshtml;
@@ -199,6 +200,11 @@ namespace OpenLiveWriter.HtmlEditor
                     // see what type of range is selected
                     range = selection.createRange();
                 }
+                catch (COMException ex)
+                {
+                    Trace.WriteLine("COMException while trying to read selection (the DOM may be in a transitional state): " + ex.Message);
+                    return null;
+                }
                 catch (UnauthorizedAccessException ex)
                 {
                     Trace.WriteLine("Exception while trying to read selection: " + ex);
@@ -262,19 +268,27 @@ namespace OpenLiveWriter.HtmlEditor
 
         private MarkupRange AdjustSelection()
         {
-            MarkupRange selection = CreateMaxSafeRange(SelectedMarkupRange);
-
-            if (selection.IsEmpty())
+            try
             {
-                MarkupRange editableRange = MarkupHelpers.GetEditableRange(selection.Start.CurrentScope, MarkupServices);
-                MarkupPointerMoveHelper.MoveUnitBounded(selection.Start,
-                                                        MarkupPointerMoveHelper.MoveDirection.LEFT,
-                                                        MarkupPointerAdjacency.BeforeVisible | MarkupPointerAdjacency.BeforeEnterScope,
-                                                        editableRange.Start);
-                selection.Collapse(true);
+                MarkupRange selection = CreateMaxSafeRange(SelectedMarkupRange);
+
+                if (selection.IsEmpty())
+                {
+                    MarkupRange editableRange = MarkupHelpers.GetEditableRange(selection.Start.CurrentScope, MarkupServices);
+                    MarkupPointerMoveHelper.MoveUnitBounded(selection.Start,
+                                                            MarkupPointerMoveHelper.MoveDirection.LEFT,
+                                                            MarkupPointerAdjacency.BeforeVisible | MarkupPointerAdjacency.BeforeEnterScope,
+                                                            editableRange.Start);
+                    selection.Collapse(true);
+                }
+                selection.ToTextRange().select();
+                return selection;
             }
-            selection.ToTextRange().select();
-            return selection;
+            catch (COMException ex)
+            {
+                Trace.WriteLine("COMException adjusting selection (the DOM may be in a transitional state): " + ex.Message);
+                return null;
+            }
         }
 
         private bool IsEditableSelection()


### PR DESCRIPTION
## Description

MSHTML selection operations crash with COMException when the document DOM is in a transitional state (e.g., during editor switching, table insertion, or content clearing).

## Changes

- `AdjustSelection`: catch COMException and return null (already handled by callers)
- `SelectedTextRange` getter: catch COMException and return null (consistent with existing UnauthorizedAccessException handling)
- `EmptySelection`: catch COMException and log via Trace

## Test plan

- [ ] Insert a table — should not crash
- [ ] Switch between editors — should not crash
- [ ] Clear editor content — should not crash

Fixes #745, Fixes #650, Fixes #644