### PR TITLE
Handle COM exceptions in MSHTML command execution

### DIFF
--- a/src/managed/OpenLiveWriter.Mshtml/MshtmlCommands.cs
+++ b/src/managed/OpenLiveWriter.Mshtml/MshtmlCommands.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using OpenLiveWriter.Interop.Com;
 
 namespace OpenLiveWriter.Mshtml
@@ -310,15 +311,19 @@ namespace OpenLiveWriter.Mshtml
         /// <param name="output">output parameter</param>
         public virtual void Execute(OLECMDEXECOPT execOption, object input, ref object output)
         {
-            if (UseNullOutputParam)
+            try
             {
-                ((IOleCommandTargetNullOutputParam)commandTarget).Exec(CGID.MSHTML, commandID, execOption, ref input, IntPtr.Zero);
+                if (UseNullOutputParam)
+                {
+                    ((IOleCommandTargetNullOutputParam)commandTarget).Exec(CGID.MSHTML, commandID, execOption, ref input, IntPtr.Zero);
+                }
+                else
+                {
+                    commandTarget.Exec(CGID.MSHTML, commandID, execOption, ref input, ref output);
+                }
             }
-            else
-            {
-                commandTarget.Exec(CGID.MSHTML, commandID, execOption, ref input, ref output);
-            }
-
+            catch (COMException) { }
+            catch (ArgumentException) { }
         }
 
         /// <summary>
@@ -328,9 +333,14 @@ namespace OpenLiveWriter.Mshtml
         public object GetValue()
         {
             object output = new object();
-            getValueCommandTarget.Exec(
-                CGID.MSHTML, commandID, OLECMDEXECOPT.DODEFAULT,
-                IntPtr.Zero, ref output);
+            try
+            {
+                getValueCommandTarget.Exec(
+                    CGID.MSHTML, commandID, OLECMDEXECOPT.DODEFAULT,
+                    IntPtr.Zero, ref output);
+            }
+            catch (COMException) { }
+            catch (ArgumentException) { }
             return output;
         }
 


### PR DESCRIPTION
## Description

`IOleCommandTarget.Exec` throws COMException or ArgumentException when the document state doesn't support the requested command, crashing the app during formatting, editing, or other MSHTML operations.

## Changes

Wrapped the `Execute` and `GetValue` methods in `MshtmlCommands.cs` with try-catch for both `COMException` and `ArgumentException`. This follows the existing pattern already used in `GetCommandStatus()` which catches all exceptions from COM calls.

## Test plan

- [ ] Apply formatting (bold, italic, etc.) — should work normally
- [ ] Edit content rapidly — should not crash from stale command state

Fixes #723, Fixes #684, Fixes #646