### PR TITLE
Handle ArgumentException in IsValidContentInsertionPoint

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/BlogPostHtmlEditorControl.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/BlogPostHtmlEditorControl.cs
@@ -1427,7 +1427,17 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
                 IHTMLElement[] editableElements = EditableElements;
                 for (int i = 0; i < editableElements.Length; i++)
                 {
-                    bounds.MoveToElement(editableElements[i], false);
+                    try
+                    {
+                        bounds.MoveToElement(editableElements[i], false);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // MoveAdjacentToElement throws ArgumentException when the
+                        // target element is invalid or detached from the DOM.
+                        // Skip this element — the insertion point is not valid here.
+                        continue;
+                    }
                     if (bounds.InRange(target))
                         return IsValidEditRegion(target);
                 }


### PR DESCRIPTION
## Description

`MoveAdjacentToElement` throws ArgumentException when the target element is invalid or detached from the DOM, crashing the content insertion validation check.

## Changes

Wrapped the `bounds.MoveToElement` call in `IsValidContentInsertionPoint` with a try-catch for `ArgumentException`. When the element is invalid, the loop continues to the next editable element. If none are valid, the method returns false.

## Test plan

- [ ] Insert content (images, plugins) — should work normally
- [ ] Edit posts with complex HTML — should not crash during insertion point validation

Fixes #706