### PR TITLE
Fix zoom keyboard shortcuts (Ctrl+=, Ctrl+-, Ctrl+0) in editor

### DIFF
--- a/src/managed/OpenLiveWriter.Mshtml/MshtmlCommands.cs
+++ b/src/managed/OpenLiveWriter.Mshtml/MshtmlCommands.cs
@@ -168,6 +168,8 @@ namespace OpenLiveWriter.Mshtml
             AddCommand(IDM.UNLINK);
             AddCommand(IDM.UNORDERLIST);
             AddCommand(IDM.VIEWSOURCE);
+            AddCommand(IDM.ZOOMPERCENT);
+            AddCommand(IDM.GETZOOM);
         }
 
         /// <summary>
@@ -823,8 +825,8 @@ namespace OpenLiveWriter.Mshtml
         public const uint REDO = 29;
         public const uint UNDO = 43;
         public const uint SELECTALL = 31;
-        //		public const uint ZOOMPERCENT =            50 ;
-        //		public const uint GETZOOM =                68 ;
+        public const uint ZOOMPERCENT = 50;
+        public const uint GETZOOM = 68;
         //		public const uint STOP =                   2138 ;
         public const uint COPY = 15;
         public const uint CUT = 16;

--- a/src/managed/OpenLiveWriter.Mshtml/MshtmlEditor.cs
+++ b/src/managed/OpenLiveWriter.Mshtml/MshtmlEditor.cs
@@ -569,6 +569,87 @@ editingOption.Key, editingOption.Value, ex.ToString()));
                 CommandKeyEventHandler(this, e);
         }
 
+        #region Zoom Handling
+
+        /// <summary>
+        /// Default zoom percentage.
+        /// </summary>
+        private const int DefaultZoomPercent = 100;
+
+        /// <summary>
+        /// Handles Ctrl+=, Ctrl+-, and Ctrl+0 zoom keyboard shortcuts by
+        /// getting the current zoom level and adjusting it accordingly.
+        /// </summary>
+        private void HandleZoomKeyboardShortcut(Keys key)
+        {
+            try
+            {
+                int currentZoom = GetCurrentZoomPercent();
+
+                int newZoom;
+                if (key == Keys.D0)
+                {
+                    // Ctrl+0: Reset zoom to 100%
+                    newZoom = DefaultZoomPercent;
+                }
+                else if (key == Keys.Oemplus)
+                {
+                    // Ctrl+=: Zoom in (next higher zoom level)
+                    newZoom = ZoomHelper.GetNextZoomLevel(currentZoom, zoomIn: true);
+                }
+                else
+                {
+                    // Ctrl+-: Zoom out (next lower zoom level)
+                    newZoom = ZoomHelper.GetNextZoomLevel(currentZoom, zoomIn: false);
+                }
+
+                if (newZoom != currentZoom)
+                {
+                    SetZoomPercent(newZoom);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.Fail("Zoom operation failed: " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Gets the current zoom percentage from MSHTML.
+        /// </summary>
+        private int GetCurrentZoomPercent()
+        {
+            try
+            {
+                if (Commands.ContainsKey(IDM.ZOOMPERCENT))
+                {
+                    object value = Commands[IDM.ZOOMPERCENT].GetValue();
+                    if (value is IConvertible && !(value is DBNull))
+                    {
+                        return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+                    }
+                }
+            }
+            catch (COMException)
+            {
+                // MSHTML may not support this command in all states
+            }
+            return DefaultZoomPercent;
+        }
+
+        /// <summary>
+        /// Sets the zoom percentage in MSHTML.
+        /// </summary>
+        private void SetZoomPercent(int zoomPercent)
+        {
+            if (Commands.ContainsKey(IDM.ZOOMPERCENT))
+            {
+                Commands[IDM.ZOOMPERCENT].Execute(zoomPercent);
+            }
+        }
+
+        #endregion
+
         /// <summary>
         /// Provide the ability to filter editor events
         /// </summary>
@@ -888,6 +969,20 @@ editingOption.Key, editingOption.Value, ex.ToString()));
             // Convert the wParam into a .Net Keys value and combine it with
             // any currently pressed modifier keys
             Keys keyData = key | ModifierKeys;
+
+            // Handle zoom keyboard shortcuts: Ctrl+= (zoom in), Ctrl+- (zoom out),
+            // and Ctrl+0 (reset zoom to 100%). Without this, Ctrl+= is consumed by
+            // the Subscript command and never reaches the zoom handler. We handle all
+            // three shortcuts here for consistency. Only plain Ctrl (no Shift) to
+            // avoid conflicts with Ctrl+Shift+= (Superscript).
+            if (ModifierKeys == Keys.Control)
+            {
+                if (key == Keys.Oemplus || key == Keys.OemMinus || key == Keys.D0)
+                {
+                    HandleZoomKeyboardShortcut(key);
+                    return HRESULT.S_OK;
+                }
+            }
 
             //	Instantiate the KeyEventArgs.
             KeyEventArgs keyEventArgs = new KeyEventArgs(keyData);

--- a/src/managed/OpenLiveWriter.Mshtml/OpenLiveWriter.Mshtml.csproj
+++ b/src/managed/OpenLiveWriter.Mshtml/OpenLiveWriter.Mshtml.csproj
@@ -50,6 +50,7 @@
     <Compile Include="MshtmlFontWrapper.cs" />
     <Compile Include="MshtmlKeyboardHook.cs" />
     <Compile Include="MshtmlMarkupServices.cs" />
+    <Compile Include="ZoomHelper.cs" />
     <Compile Include="Mshtml_Interop\ElementBehaviorFactoryForExistingBehavior.cs" />
     <Compile Include="Mshtml_Interop\HtmlElementEvents2DispIds.cs" />
     <Compile Include="Mshtml_Interop\ICustomDoc.cs" />

--- a/src/managed/OpenLiveWriter.Mshtml/ZoomHelper.cs
+++ b/src/managed/OpenLiveWriter.Mshtml/ZoomHelper.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+namespace OpenLiveWriter.Mshtml
+{
+    /// <summary>
+    /// Helper class for editor zoom level calculations.
+    /// </summary>
+    public static class ZoomHelper
+    {
+        /// <summary>
+        /// Standard zoom percentage levels matching browser zoom behavior.
+        /// </summary>
+        public static readonly int[] ZoomLevels = { 25, 33, 50, 67, 75, 80, 90, 100, 110, 125, 150, 175, 200, 250, 300, 400, 500 };
+
+        /// <summary>
+        /// Gets the next zoom level in the given direction from the predefined zoom steps.
+        /// </summary>
+        /// <param name="currentZoom">The current zoom percentage.</param>
+        /// <param name="zoomIn">True to zoom in (increase), false to zoom out (decrease).</param>
+        /// <returns>The next zoom percentage in the requested direction.</returns>
+        public static int GetNextZoomLevel(int currentZoom, bool zoomIn)
+        {
+            if (zoomIn)
+            {
+                // Find the next level above current zoom
+                for (int i = 0; i < ZoomLevels.Length; i++)
+                {
+                    if (ZoomLevels[i] > currentZoom)
+                        return ZoomLevels[i];
+                }
+                return ZoomLevels[ZoomLevels.Length - 1]; // Already at max
+            }
+            else
+            {
+                // Find the next level below current zoom
+                for (int i = ZoomLevels.Length - 1; i >= 0; i--)
+                {
+                    if (ZoomLevels[i] < currentZoom)
+                        return ZoomLevels[i];
+                }
+                return ZoomLevels[0]; // Already at min
+            }
+        }
+    }
+}

--- a/src/managed/OpenLiveWriter.UnitTest/Mshtml/ZoomHelperTests.cs
+++ b/src/managed/OpenLiveWriter.UnitTest/Mshtml/ZoomHelperTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenLiveWriter.Mshtml;
+
+namespace OpenLiveWriter.UnitTest.Mshtml
+{
+    [TestClass]
+    public class ZoomHelperTests
+    {
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomIn_FromDefault_Returns110()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(100, zoomIn: true);
+            Assert.AreEqual(110, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomOut_FromDefault_Returns90()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(100, zoomIn: false);
+            Assert.AreEqual(90, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomIn_FromMinimum_Returns33()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(25, zoomIn: true);
+            Assert.AreEqual(33, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomOut_FromMaximum_Returns400()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(500, zoomIn: false);
+            Assert.AreEqual(400, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomIn_AtMaximum_StaysAtMaximum()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(500, zoomIn: true);
+            Assert.AreEqual(500, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomOut_AtMinimum_StaysAtMinimum()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(25, zoomIn: false);
+            Assert.AreEqual(25, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomIn_FromNonStandardValue_ReturnsNextStep()
+        {
+            // Current zoom is 115 (between 110 and 125), next step up should be 125
+            int result = ZoomHelper.GetNextZoomLevel(115, zoomIn: true);
+            Assert.AreEqual(125, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomOut_FromNonStandardValue_ReturnsNextStep()
+        {
+            // Current zoom is 115 (between 110 and 125), next step down should be 110
+            int result = ZoomHelper.GetNextZoomLevel(115, zoomIn: false);
+            Assert.AreEqual(110, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomIn_From125_Returns150()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(125, zoomIn: true);
+            Assert.AreEqual(150, result);
+        }
+
+        [TestMethod]
+        public void GetNextZoomLevel_ZoomOut_From75_Returns67()
+        {
+            int result = ZoomHelper.GetNextZoomLevel(75, zoomIn: false);
+            Assert.AreEqual(67, result);
+        }
+
+        [TestMethod]
+        public void ZoomLevels_ContainsDefaultZoom()
+        {
+            bool contains100 = false;
+            foreach (int level in ZoomHelper.ZoomLevels)
+            {
+                if (level == 100)
+                {
+                    contains100 = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(contains100, "ZoomLevels should contain the default 100% level.");
+        }
+
+        [TestMethod]
+        public void ZoomLevels_AreInAscendingOrder()
+        {
+            for (int i = 1; i < ZoomHelper.ZoomLevels.Length; i++)
+            {
+                Assert.IsTrue(ZoomHelper.ZoomLevels[i] > ZoomHelper.ZoomLevels[i - 1],
+                    "ZoomLevels should be in ascending order.");
+            }
+        }
+    }
+}

--- a/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
+++ b/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
@@ -92,6 +92,10 @@
       <Project>{D6C9A393-E0B8-4548-B84B-F8B6FE2A5645}</Project>
       <Name>OpenLiveWriter.PostEditor</Name>
     </ProjectReference>
+    <ProjectReference Include="..\OpenLiveWriter.Mshtml\OpenLiveWriter.Mshtml.csproj">
+      <Project>{906BA039-467B-41AE-B805-BA1B837AB763}</Project>
+      <Name>OpenLiveWriter.Mshtml</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="CoreServices\ResourceDownloading\SupportingCabs\Unsigned_1529.0310.cab">
@@ -108,6 +112,7 @@
     <Compile Include="HtmlEditor\WordCounterTests\HebrewTextWordCount.cs" />
     <Compile Include="PostEditor\Tables\TableEditorDisposeTest.cs" />
     <Compile Include="PostEditor\MalformedUrlHandlingTest.cs" />
+    <Compile Include="Mshtml\ZoomHelperTests.cs" />
     <Compile Include="PostEditor\PostEditorStorageExceptionTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Ctrl+= (zoom in) and Ctrl+0 (zoom reset) don't work in the editor. Only Ctrl+- (zoom out) works because MSHTML handles it natively. Ctrl+= was being consumed by the Subscript command's keyboard shortcut binding.

## Changes

- Intercepts Ctrl+=, Ctrl+-, and Ctrl+0 in `MshtmlEditor.TranslateAccelerator` before command processing
- Implements programmatic zoom using MSHTML's `IDM.ZOOMPERCENT` command
- Uses standard browser zoom levels (25% to 500%) with `ZoomHelper`
- Uncommented `IDM.ZOOMPERCENT` and `IDM.GETZOOM` constants in MshtmlCommands
- Only intercepts Ctrl (no Shift) to preserve Ctrl+Shift+= (Superscript)

## Tests (10 tests)

- Zoom-in level progression through standard steps
- Zoom-out level progression
- Boundary conditions (min/max zoom)
- Non-standard zoom value snapping
- Zoom level array invariants

## Test plan

- [ ] Ctrl+= zooms in
- [ ] Ctrl+- zooms out
- [ ] Ctrl+0 resets to 100%
- [ ] Ctrl+Shift+= still triggers Superscript

Fixes #752