### PR TITLE
Fix OutOfMemoryException in ImageInsertHandler.WriteImages

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/ImageEditing/ImageInsertHandler.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/ImageEditing/ImageInsertHandler.cs
@@ -56,9 +56,11 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
             ImageFilter inlineFilter = ImageFilterDecoratorAdapter.CreateImageDecoratorsFilter(imageInfo, ImageEmbedType.Embedded, invocationSource, clientOptions);
             ImageFilter targetFilter = ImageFilterDecoratorAdapter.CreateImageDecoratorsFilter(imageInfo, ImageEmbedType.Linked, invocationSource, clientOptions);
 
-            using (Bitmap inlineBitmap = new Bitmap(imageInfo.ImageSourceUri.LocalPath))
+            string imagePath = imageInfo.ImageSourceUri.LocalPath;
+
+            using (Bitmap inlineBitmap = LoadBitmapWithOomProtection(imagePath))
             {
-                string imgPath = writeImage(inlineBitmap, imageInfo.ImageSourceUri.LocalPath, inlinePrefix, inlineFilter, inlineFileCreator);
+                string imgPath = writeImage(inlineBitmap, imagePath, inlinePrefix, inlineFilter, inlineFileCreator);
                 string inlineImgPath = new Uri(UrlHelper.CreateUrlFromPath(imgPath)).ToString();
                 imageInfo.InlineImageUrl = inlineImgPath;
             }
@@ -70,9 +72,9 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
             //imageInfo.LinkTarget = origLinkTarget;
             if (imageInfo.LinkTarget == LinkTargetType.IMAGE && !ImageDecoratorDirective.ShouldSuppressLinked)
             {
-                using (Bitmap targetBitmap = new Bitmap(imageInfo.ImageSourceUri.LocalPath))
+                using (Bitmap targetBitmap = LoadBitmapWithOomProtection(imagePath))
                 {
-                    string anchorPath = writeImage(targetBitmap, imageInfo.ImageSourceUri.LocalPath, "", targetFilter, linkedFileCreator);
+                    string anchorPath = writeImage(targetBitmap, imagePath, "", targetFilter, linkedFileCreator);
                     string targetUrl = new Uri(UrlHelper.CreateUrlFromPath(anchorPath)).ToString();
                     imageInfo.LinkTargetUrl = targetUrl;
                 }
@@ -125,7 +127,7 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
 
         public static Size WriteImageToFile(string sourceFile, int width, int height, string outputFile, bool preserveConstraints)
         {
-            using (Bitmap sourceImage = new Bitmap(sourceFile))
+            using (Bitmap sourceImage = LoadBitmapWithOomProtection(sourceFile))
             {
                 FixImageOrientation(sourceImage);
                 using (Stream imageOut = new FileStream(outputFile, FileMode.Create, FileAccess.Write))
@@ -145,7 +147,7 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
             }
             if (preserveConstraints)
             {
-                using (Bitmap img = new Bitmap(outputFile))
+                using (Bitmap img = LoadBitmapWithOomProtection(outputFile))
                     return img.Size;
             }
             else
@@ -185,6 +187,28 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
             catch (Exception)
             {
                 //image.PropertyItems will throw an exception if the image does not contain any exif data
+            }
+        }
+
+        /// <summary>
+        /// Loads a Bitmap from the specified file path, converting OutOfMemoryException
+        /// into a user-friendly BlogClientFileTransferException.
+        /// GDI+ throws OutOfMemoryException both for genuinely large images that exhaust
+        /// memory and for corrupt/unsupported image files.
+        /// </summary>
+        internal static Bitmap LoadBitmapWithOomProtection(string filePath)
+        {
+            try
+            {
+                return new Bitmap(filePath);
+            }
+            catch (OutOfMemoryException)
+            {
+                string fileName = Path.GetFileName(filePath);
+                throw new BlogClientFileTransferException(
+                    string.Format(CultureInfo.CurrentCulture, "Processing image: {0}", fileName),
+                    "ImageTooLarge",
+                    "The image is too large to process. Try resizing it to a smaller resolution before inserting.");
             }
         }
     }

--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/ImageEditing/ImageInsertHandler.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/ImageEditing/ImageInsertHandler.cs
@@ -196,7 +196,7 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing
         /// GDI+ throws OutOfMemoryException both for genuinely large images that exhaust
         /// memory and for corrupt/unsupported image files.
         /// </summary>
-        internal static Bitmap LoadBitmapWithOomProtection(string filePath)
+        public static Bitmap LoadBitmapWithOomProtection(string filePath)
         {
             try
             {

--- a/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
+++ b/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
@@ -31,6 +31,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
+++ b/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
@@ -114,6 +114,7 @@
     <Compile Include="PostEditor\MalformedUrlHandlingTest.cs" />
     <Compile Include="Mshtml\ZoomHelperTests.cs" />
     <Compile Include="PostEditor\PostEditorStorageExceptionTests.cs" />
+    <Compile Include="PostEditor\ImageInsertHandlerTests.cs" />
     <Compile Include="SpellChecker\SpellingLanguageFallbackTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/managed/OpenLiveWriter.UnitTest/PostEditor/ImageInsertHandlerTests.cs
+++ b/src/managed/OpenLiveWriter.UnitTest/PostEditor/ImageInsertHandlerTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using System;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenLiveWriter.Extensibility.BlogClient;
@@ -14,19 +12,25 @@ namespace OpenLiveWriter.UnitTest.PostEditor
     [TestClass]
     public class ImageInsertHandlerTests
     {
+        // Minimal valid 1x1 white PNG (67 bytes)
+        private static readonly byte[] MinimalPng = {
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+            0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00,
+            0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+            0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, 0x00, 0x00, 0x00,
+            0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+        };
+
         [TestMethod]
         public void LoadBitmapWithOomProtection_ValidImage_ReturnsBitmap()
         {
-            string tempFile = Path.GetTempFileName();
+            string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".png");
             try
             {
-                // Create a small valid image
-                using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format32bppArgb))
-                {
-                    bmp.Save(tempFile, ImageFormat.Png);
-                }
+                File.WriteAllBytes(tempFile, MinimalPng);
 
-                using (Bitmap result = ImageInsertHandler.LoadBitmapWithOomProtection(tempFile))
+                using (var result = ImageInsertHandler.LoadBitmapWithOomProtection(tempFile))
                 {
                     Assert.IsNotNull(result);
                     Assert.AreEqual(1, result.Width);

--- a/src/managed/OpenLiveWriter.UnitTest/PostEditor/ImageInsertHandlerTests.cs
+++ b/src/managed/OpenLiveWriter.UnitTest/PostEditor/ImageInsertHandlerTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenLiveWriter.Extensibility.BlogClient;
+using OpenLiveWriter.PostEditor.PostHtmlEditing;
+
+namespace OpenLiveWriter.UnitTest.PostEditor
+{
+    [TestClass]
+    public class ImageInsertHandlerTests
+    {
+        [TestMethod]
+        public void LoadBitmapWithOomProtection_ValidImage_ReturnsBitmap()
+        {
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                // Create a small valid image
+                using (Bitmap bmp = new Bitmap(1, 1, PixelFormat.Format32bppArgb))
+                {
+                    bmp.Save(tempFile, ImageFormat.Png);
+                }
+
+                using (Bitmap result = ImageInsertHandler.LoadBitmapWithOomProtection(tempFile))
+                {
+                    Assert.IsNotNull(result);
+                    Assert.AreEqual(1, result.Width);
+                    Assert.AreEqual(1, result.Height);
+                }
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+            }
+        }
+
+        [TestMethod]
+        public void LoadBitmapWithOomProtection_InvalidImage_ThrowsBlogClientFileTransferException()
+        {
+            // GDI+ throws OutOfMemoryException for corrupt/unsupported image files
+            string tempFile = Path.GetTempFileName();
+            try
+            {
+                // Write garbage data that is not a valid image format
+                File.WriteAllBytes(tempFile, new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 });
+
+                try
+                {
+                    ImageInsertHandler.LoadBitmapWithOomProtection(tempFile);
+                    Assert.Fail("Expected BlogClientFileTransferException was not thrown.");
+                }
+                catch (BlogClientFileTransferException)
+                {
+                    // Expected: OOM from GDI+ is caught and wrapped
+                }
+            }
+            finally
+            {
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+            }
+        }
+
+        [TestMethod]
+        public void LoadBitmapWithOomProtection_NonExistentFile_ThrowsArgumentException()
+        {
+            // Bitmap constructor throws ArgumentException for files that don't exist
+            string fakePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".png");
+
+            try
+            {
+                ImageInsertHandler.LoadBitmapWithOomProtection(fakePath);
+                Assert.Fail("Expected an exception for non-existent file.");
+            }
+            catch (ArgumentException)
+            {
+                // Expected: non-OOM exceptions pass through unmodified
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Large or corrupt images cause OutOfMemoryException when inserted into posts. GDI+ throws OOM for both genuinely large images and unsupported/corrupt files.

## Changes

Added `LoadBitmapWithOomProtection()` helper that wraps `new Bitmap()` and converts OOM to a user-friendly `BlogClientFileTransferException` with guidance to resize the image. All four bitmap load sites in `WriteImages` and `WriteImageToFile` now use this helper.

## Tests (3 tests)

- Valid image loads successfully
- Invalid/corrupt image data throws friendly exception (not raw OOM)
- Non-existent file passes through original ArgumentException

## Test plan

- [ ] Insert a normal image — works as before
- [ ] Insert a very large image (50MB+) — shows friendly error instead of crash
- [ ] Insert a corrupt image file — shows friendly error

Fixes #747