### PR TITLE
Fix XML-RPC response parsing for malformed/truncated server responses

### DIFF
--- a/src/managed/OpenLiveWriter.CoreServices/XmlRpcClient.cs
+++ b/src/managed/OpenLiveWriter.CoreServices/XmlRpcClient.cs
@@ -7,9 +7,12 @@ using System.Globalization;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml;
 using OpenLiveWriter.CoreServices.Diagnostics;
+
+[assembly: InternalsVisibleTo("OpenLiveWriter.UnitTest")]
 
 namespace OpenLiveWriter.CoreServices
 {
@@ -490,7 +493,16 @@ namespace OpenLiveWriter.CoreServices
                 // analyze the response text to determine the content of the response
                 XmlDocument document = new XmlDocument();
                 if (responseText != null)
-                    responseText = responseText.TrimStart(' ', '\t', '\r', '\n');
+                    responseText = responseText.Trim();
+
+                if (string.IsNullOrEmpty(responseText))
+                    throw new ArgumentException("XML-RPC response was null or empty");
+
+                Trace.WriteLine(string.Format("XmlRpc response length: {0}", responseText.Length));
+
+                if (!responseText.EndsWith(">"))
+                    Trace.WriteLine("WARNING: XML-RPC response may be truncated (does not end with '>')");
+
                 document.LoadXml(responseText);
                 XmlNode responseValue = document.SelectSingleNode("/methodResponse/params/param/value");
                 if (responseValue != null)
@@ -509,6 +521,16 @@ namespace OpenLiveWriter.CoreServices
                     _faultString = errorString.InnerText;
                 }
 
+            }
+            catch (XmlException ex)
+            {
+                string truncationWarning = responseText != null && !responseText.EndsWith(">")
+                    ? " Response may be truncated." : "";
+                string message = string.Format(
+                    "Invalid XML-RPC response document (length: {0}).{1}",
+                    responseText != null ? responseText.Length.ToString() : "null",
+                    truncationWarning);
+                throw new XmlRpcClientInvalidResponseException(message, responseText, ex);
             }
             catch (Exception ex)
             {
@@ -558,6 +580,12 @@ namespace OpenLiveWriter.CoreServices
     {
         public XmlRpcClientInvalidResponseException(string response, Exception innerException)
             : base("Invalid response document returned from XmlRpc server", innerException)
+        {
+            Response = response;
+        }
+
+        public XmlRpcClientInvalidResponseException(string message, string response, Exception innerException)
+            : base(message, innerException)
         {
             Response = response;
         }

--- a/src/managed/OpenLiveWriter.UnitTest/CoreServices/XmlRpcResponseParsingTests.cs
+++ b/src/managed/OpenLiveWriter.UnitTest/CoreServices/XmlRpcResponseParsingTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenLiveWriter.CoreServices;
+
+namespace OpenLiveWriter.UnitTest.CoreServices
+{
+    [TestClass]
+    public class XmlRpcResponseParsingTests
+    {
+        private const string ValidXmlRpcResponse =
+            "<?xml version=\"1.0\"?>" +
+            "<methodResponse>" +
+            "<params><param><value><string>Hello</string></value></param></params>" +
+            "</methodResponse>";
+
+        [TestMethod]
+        public void ValidXmlRpcResponse_ParsesSuccessfully()
+        {
+            var response = new XmlRpcMethodResponse(ValidXmlRpcResponse);
+            Assert.IsFalse(response.FaultOccurred);
+            Assert.IsNotNull(response.Response);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(XmlRpcClientInvalidResponseException))]
+        public void MalformedXml_ThrowsInvalidResponseException()
+        {
+            new XmlRpcMethodResponse("<methodResponse><params><param><value>unclosed");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(XmlRpcClientInvalidResponseException))]
+        public void NullResponse_ThrowsInvalidResponseException()
+        {
+            new XmlRpcMethodResponse((string)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(XmlRpcClientInvalidResponseException))]
+        public void EmptyResponse_ThrowsInvalidResponseException()
+        {
+            new XmlRpcMethodResponse(string.Empty);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(XmlRpcClientInvalidResponseException))]
+        public void WhitespaceOnlyResponse_ThrowsInvalidResponseException()
+        {
+            new XmlRpcMethodResponse("   \t\r\n   ");
+        }
+    }
+}

--- a/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
+++ b/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
@@ -110,6 +110,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CoreServices\XmlFileSettingsPersisterTest.cs" />
+    <Compile Include="CoreServices\XmlRpcResponseParsingTests.cs" />
     <Compile Include="HtmlEditor\WordCounterTests\HebrewTextWordCount.cs" />
     <Compile Include="PostEditor\Tables\TableEditorDisposeTest.cs" />
     <Compile Include="PostEditor\MalformedUrlHandlingTest.cs" />


### PR DESCRIPTION
## Description

When blog servers return malformed or truncated XML-RPC responses, the error message is generic and unhelpful, making debugging difficult.

## Changes

- Added `Trim()` (both ends) instead of just `TrimStart()` before XML parsing
- Added null/empty response validation with clear error message
- Added truncation detection (response not ending with `>`)
- Added `Trace.WriteLine` logging of response length for debugging
- Added specific `XmlException` catch with descriptive error including response length
- New `XmlRpcClientInvalidResponseException` constructor overload with custom message

## Tests (5 tests)

- Valid XML-RPC response parses successfully
- Malformed XML throws descriptive exception
- Null response throws appropriate exception
- Empty response throws appropriate exception
- Whitespace-only response throws appropriate exception

## Test plan

- [ ] Connect to a working blog server — works as before
- [ ] Connect to a server returning malformed XML — shows descriptive error

Fixes #739