### PR TITLE
Remove Gitter chat references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,4 @@ If you haven't already, please sign the [.NET Foundation CLA](http://cla2.dotnet
 permission to include your contributions in the next release of Open Live Writer.
 
 If you would like to discuss a change you are thinking of doing before you start work on it then feel free to raise an
-issue. The developers for Open Live Writer [chat on Gitter](https://gitter.im/OpenLiveWriter/OpenLiveWriter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) when they are online 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OpenLiveWriter/OpenLiveWriter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+issue, or start a thread on [GitHub Discussions](https://github.com/OpenLiveWriter/OpenLiveWriter/discussions).

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ This project has adopted the code of conduct defined by the [Contributor Covenan
 to clarify expected behavior in our community.
 For more information see the [.NET Foundation Code of Conduct](http://www.dotnetfoundation.org/code-of-conduct).
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OpenLiveWriter/OpenLiveWriter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-
 ### License
 Open Live Writer proudly uses the [MIT License](license.txt).
 


### PR DESCRIPTION
## Summary
- Gitter (gitter.im) has shut down, per [Wikipedia](https://en.wikipedia.org/wiki/Gitter), so the badges and links in this repo no longer lead anywhere useful.
- Removes the Gitter badge from `README.md`.
- Replaces the Gitter chat pointer in `CONTRIBUTING.md` with a link to GitHub Discussions on this repo, which is already enabled.

## Test plan
- [x] Verify no other Gitter references remain in non-localization files (the `Gitter` strings in `intl/` are Danish/Luxembourgish for "grid" and are unrelated).
- [x] Verify rendered Markdown locally.
- [ ] Maintainer review.