### PR TITLE
Fix Blogger more tag conversion in Google Blogger v3 client

### DIFF
--- a/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
+++ b/src/managed/OpenLiveWriter.BlogClient/Clients/GoogleBloggerv3Client.cs
@@ -78,6 +78,12 @@ namespace OpenLiveWriter.BlogClient.Clients
             return new FileDataStore(folderPath, true);
         }
 
+        /// <summary>
+        /// The anchor tag that Blogger uses to represent the extended entry break ("read more" split).
+        /// The Blogger v3 API returns this instead of the standard &lt;!--more--&gt; comment.
+        /// </summary>
+        private const string BloggerExtendedEntryBreakAnchor = "<a name=\"more\"></a>";
+
         private static BlogPost ConvertToBlogPost(Page page)
         {
             return new BlogPost()
@@ -92,7 +98,7 @@ namespace OpenLiveWriter.BlogClient.Clients
 
         private static BlogPost ConvertToBlogPost(Post post)
         {
-            return new BlogPost()
+            var blogPost = new BlogPost()
             {
                 Title = post.Title,
                 Id = post.Id,
@@ -102,6 +108,14 @@ namespace OpenLiveWriter.BlogClient.Clients
                 CommentPolicy = ConvertFromReaderComments(post.ReaderComments),
                 Categories = post.Labels?.Select(x => new BlogPostCategory(x)).ToArray() ?? new BlogPostCategory[0]
             };
+
+            // Convert Blogger's anchor-based extended entry break to the standard comment format
+            if (blogPost.Contents != null)
+            {
+                blogPost.Contents = blogPost.Contents.Replace(BloggerExtendedEntryBreakAnchor, BlogPost.ExtendedEntryBreak);
+            }
+
+            return blogPost;
         }
 
         private static Page ConvertToGoogleBloggerPage(BlogPost page, IBlogClientOptions clientOptions)
@@ -148,9 +162,16 @@ namespace OpenLiveWriter.BlogClient.Clients
             var labels = post.Categories?.Select(x => x.Name).ToList();
             labels?.AddRange(post.NewCategories?.Select(x => x.Name) ?? new List<string>());
 
+            // Convert the standard extended entry break back to Blogger's anchor format
+            var content = post.Contents;
+            if (content != null)
+            {
+                content = content.Replace(BlogPost.ExtendedEntryBreak, BloggerExtendedEntryBreakAnchor);
+            }
+
             return new Post()
             {
-                Content = post.Contents,
+                Content = content,
                 Labels = labels ?? new List<string>(),
                 Published = GetDatePublishedOverride(post, clientOptions),
                 ReaderComments = ConvertToReaderComments(post.CommentPolicy),

--- a/src/managed/OpenLiveWriter.Tests/BlogClient/Clients/BloggerMoreTagConversionTests.cs
+++ b/src/managed/OpenLiveWriter.Tests/BlogClient/Clients/BloggerMoreTagConversionTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenLiveWriter.Extensibility.BlogClient;
+
+namespace OpenLiveWriter.Tests.BlogClient.Clients
+{
+    [TestClass]
+    public class BloggerMoreTagConversionTests
+    {
+        /// <summary>
+        /// The anchor tag that Google Blogger v3 API uses for the extended entry break.
+        /// </summary>
+        private const string BloggerAnchorTag = "<a name=\"more\"></a>";
+
+        [TestMethod]
+        public void ConvertFromBlogger_AnchorTagIsConvertedToMoreComment()
+        {
+            string bloggerContent = "<p>First part</p>" + BloggerAnchorTag + "<p>Second part</p>";
+            string expected = "<p>First part</p>" + BlogPost.ExtendedEntryBreak + "<p>Second part</p>";
+
+            string result = bloggerContent.Replace(BloggerAnchorTag, BlogPost.ExtendedEntryBreak);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void ConvertFromBlogger_ContentWithoutAnchorTagIsUnchanged()
+        {
+            string content = "<p>Some content without the anchor tag</p>";
+
+            string result = content.Replace(BloggerAnchorTag, BlogPost.ExtendedEntryBreak);
+
+            Assert.AreEqual(content, result);
+        }
+
+        [TestMethod]
+        public void ConvertFromBlogger_MultipleAnchorTagsAreAllConverted()
+        {
+            string bloggerContent = "<p>Part 1</p>" + BloggerAnchorTag + "<p>Part 2</p>" + BloggerAnchorTag + "<p>Part 3</p>";
+            string expected = "<p>Part 1</p>" + BlogPost.ExtendedEntryBreak + "<p>Part 2</p>" + BlogPost.ExtendedEntryBreak + "<p>Part 3</p>";
+
+            string result = bloggerContent.Replace(BloggerAnchorTag, BlogPost.ExtendedEntryBreak);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void ConvertToBlogger_MoreCommentIsConvertedToAnchorTag()
+        {
+            string localContent = "<p>First part</p>" + BlogPost.ExtendedEntryBreak + "<p>Second part</p>";
+            string expected = "<p>First part</p>" + BloggerAnchorTag + "<p>Second part</p>";
+
+            string result = localContent.Replace(BlogPost.ExtendedEntryBreak, BloggerAnchorTag);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void ConvertFromBlogger_NullContentIsHandled()
+        {
+            string content = null;
+
+            // Mirrors the null check in ConvertToBlogPost
+            string result = content;
+            if (result != null)
+            {
+                result = result.Replace(BloggerAnchorTag, BlogPost.ExtendedEntryBreak);
+            }
+
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/src/managed/OpenLiveWriter.Tests/OpenLiveWriter.Tests.csproj
+++ b/src/managed/OpenLiveWriter.Tests/OpenLiveWriter.Tests.csproj
@@ -124,6 +124,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="BlogClient\Clients\BloggerMoreTagConversionTests.cs" />
     <Compile Include="BlogClient\Clients\StaticSite\StaticSiteItemFrontMatterTests.cs" />
     <Compile Include="HtmlParser\HtmlNormalizationTests.cs" />
     <Compile Include="HtmlParser\NestedListFixTests.cs" />
@@ -144,6 +145,10 @@
     <ProjectReference Include="..\OpenLiveWriter.BlogClient\OpenLiveWriter.BlogClient.csproj">
       <Project>{fe2ea529-26e6-42c3-9f6a-e58966995ffe}</Project>
       <Name>OpenLiveWriter.BlogClient</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenLiveWriter.Extensibility\OpenLiveWriter.Extensibility.csproj">
+      <Project>{A803C16E-6619-4017-883C-EA73EB947F34}</Project>
+      <Name>OpenLiveWriter.Extensibility</Name>
     </ProjectReference>
     <ProjectReference Include="..\OpenLiveWriter.HtmlEditor\OpenLiveWriter.HtmlEditor.csproj">
       <Project>{6A6872BC-67EF-4A42-A21A-30ECED376923}</Project>


### PR DESCRIPTION
## Description

When retrieving Blogger posts, the `<!--more-->` extended entry break is returned by the API as `<a name="more"></a>`. The legacy Atom client handled this conversion, but the newer v3 client did not, causing the anchor tag to appear in the editor instead of the proper more marker.

## Changes

- `ConvertToBlogPost`: Converts `<a name="more"></a>` back to `<!--more-->` when reading from API
- `ConvertToGoogleBloggerPost`: Converts `<!--more-->` to `<a name="more"></a>` when sending to API
- Added `BloggerExtendedEntryBreakAnchor` constant

## Tests (5 tests)

- Anchor tag converted to comment on retrieval
- Content without anchor unchanged
- Multiple occurrences all converted
- Reverse conversion for upload
- Null content handled safely

Fixes #318