### PR TITLE
Preserve alt text when pasting images

### DIFF
--- a/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/ImageEditing/Decorators/HtmlAltTextDecorator.cs
+++ b/src/managed/OpenLiveWriter.PostEditor/PostHtmlEditing/ImageEditing/Decorators/HtmlAltTextDecorator.cs
@@ -35,6 +35,12 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing.ImageEditing.Decorators
                 )
             {
                 HtmlAltTextDecoratorSettings settings = new HtmlAltTextDecoratorSettings(context.ImgElement);
+
+                // Don't overwrite existing non-default alt text (e.g., from clipboard paste)
+                string existingAlt = settings.AltText;
+                if (ShouldPreserveAltText(existingAlt))
+                    return;
+
                 Uri uri = context.SourceImageUri;
 
                 //set the default AltText value
@@ -42,6 +48,17 @@ namespace OpenLiveWriter.PostEditor.PostHtmlEditing.ImageEditing.Decorators
                 settings.AltText = altText;
                 settings.Title = altText;
             }
+        }
+
+        /// <summary>
+        /// Determines whether existing alt text should be preserved rather than
+        /// replaced with a default value. Alt text is preserved when it is
+        /// non-empty and not the generic default "image".
+        /// </summary>
+        internal static bool ShouldPreserveAltText(string altText)
+        {
+            return !string.IsNullOrEmpty(altText)
+                && !string.Equals(altText, "image", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
+++ b/src/managed/OpenLiveWriter.UnitTest/OpenLiveWriter.UnitTest.csproj
@@ -135,6 +135,7 @@
     <Compile Include="PostEditor\NullRibbonControlTest.cs" />
     <Compile Include="BlogClient\PostDateTimezoneTest.cs" />
     <Compile Include="Controls\ImageCropMakeGrayTest.cs" />
+    <Compile Include="PostEditor\HtmlAltTextDecoratorTests.cs" />
     <Compile Include="SpellChecker\SpellCheckerInitializationTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/managed/OpenLiveWriter.UnitTest/PostEditor/HtmlAltTextDecoratorTests.cs
+++ b/src/managed/OpenLiveWriter.UnitTest/PostEditor/HtmlAltTextDecoratorTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenLiveWriter.PostEditor.PostHtmlEditing.ImageEditing.Decorators;
+
+namespace OpenLiveWriter.UnitTest.PostEditor
+{
+    [TestClass]
+    public class HtmlAltTextDecoratorTests
+    {
+        [TestMethod]
+        public void ShouldPreserveAltText_WithMeaningfulAlt_ReturnsTrue()
+        {
+            Assert.IsTrue(HtmlAltTextDecorator.ShouldPreserveAltText("A photo of a sunset"));
+        }
+
+        [TestMethod]
+        public void ShouldPreserveAltText_WithDefaultImage_ReturnsFalse()
+        {
+            Assert.IsFalse(HtmlAltTextDecorator.ShouldPreserveAltText("image"));
+        }
+
+        [TestMethod]
+        public void ShouldPreserveAltText_WithDefaultImageUpperCase_ReturnsFalse()
+        {
+            Assert.IsFalse(HtmlAltTextDecorator.ShouldPreserveAltText("Image"));
+        }
+
+        [TestMethod]
+        public void ShouldPreserveAltText_WithEmptyString_ReturnsFalse()
+        {
+            Assert.IsFalse(HtmlAltTextDecorator.ShouldPreserveAltText(""));
+        }
+
+        [TestMethod]
+        public void ShouldPreserveAltText_WithNull_ReturnsFalse()
+        {
+            Assert.IsFalse(HtmlAltTextDecorator.ShouldPreserveAltText(null));
+        }
+
+        [TestMethod]
+        public void ShouldPreserveAltText_WithWhitespaceOnly_ReturnsTrue()
+        {
+            // Whitespace-only alt text is non-empty and non-default, so it is
+            // treated as intentionally set (e.g., decorative image convention).
+            Assert.IsTrue(HtmlAltTextDecorator.ShouldPreserveAltText("   "));
+        }
+
+        [TestMethod]
+        public void ShouldPreserveAltText_WithImageSubstring_ReturnsTrue()
+        {
+            // "image" as part of a longer string is meaningful alt text
+            Assert.IsTrue(HtmlAltTextDecorator.ShouldPreserveAltText("An image of a cat"));
+        }
+    }
+}


### PR DESCRIPTION
## Description

When copying an image with alt text and pasting it, the alt attribute is lost and replaced with the default "image". The `HtmlAltTextDecorator` unconditionally overwrites alt text during initial insert without checking if meaningful alt text already exists.

## Changes

Added `ShouldPreserveAltText()` check in `HtmlAltTextDecorator.Decorate()`. Before applying defaults, checks if the image already has non-default alt text (not null, not empty, not "image"). If so, preserves it.

## Tests (7 tests)

- Meaningful alt text is preserved
- Default "image" is replaced
- Case-insensitive "Image" is replaced
- Empty string is replaced
- Null is replaced
- Whitespace-only is preserved (may be intentional)
- "image" as substring of longer text is preserved

Fixes #337